### PR TITLE
fix Flowvar allocation

### DIFF
--- a/taskpools.nim
+++ b/taskpools.nim
@@ -1,5 +1,5 @@
-# Nim-Taskpools
-# Copyright (c) 2021 Status Research & Development GmbH
+# taskpools
+# Copyright (c) 2021- Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).

--- a/taskpools/ast_utils.nim
+++ b/taskpools/ast_utils.nim
@@ -1,4 +1,4 @@
-# Nim-Taskpools
+# taskpools
 # Copyright (c) 2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).

--- a/taskpools/channels_spsc_single.nim
+++ b/taskpools/channels_spsc_single.nim
@@ -1,17 +1,19 @@
-# Weave
+# taskpools
 # Copyright (c) 2019 Mamy André-Ratsimbazafy
+# Copyright (c) 2021- Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
+
 import
-  std/atomics,
-  ./instrumentation/[contracts, loggers]
+  std/[atomics, typetraits]
 
 type
-  ChannelSPSCSingle* = object
-    ## A type-erased SPSC channel.
+  ChannelSPSCSingle*[T] = object
+    ## A single-value SPSC channel
     ##
     ## Wait-free bounded single-producer single-consumer channel
     ## that can only buffer a single item
@@ -25,23 +27,12 @@ type
     ##
     ## The channel should be the last field of an object if used in an intrusive manner
     full{.align: 64.}: Atomic[bool]
-    itemSize*: uint8
-    buffer*{.align: 8.}: UncheckedArray[byte]
+    value*: T
 
-{.push raises: [AssertionDefect].} # Ensure no exceptions can happen
-
-proc `=`(
-    dest: var ChannelSPSCSingle,
-    source: ChannelSPSCSingle
+proc `=copy`[T](
+    dest: var ChannelSPSCSingle[T],
+    source: ChannelSPSCSingle[T]
   ) {.error: "A channel cannot be copied".}
-
-proc initialize*(chan: var ChannelSPSCSingle, itemsize: SomeInteger) {.inline.} =
-  ## If ChannelSPSCSingle is used intrusive another data structure
-  ## be aware that it should be the last part due to ending by UncheckedArray
-  preCondition: itemsize.int in 0 .. int high(uint8)
-
-  chan.itemSize = uint8 itemsize
-  chan.full.store(false, moRelaxed)
 
 func isEmpty*(chan: var ChannelSPSCSingle): bool {.inline.} =
   not chan.full.load(moAcquire)
@@ -51,34 +42,33 @@ func tryRecv*[T](chan: var ChannelSPSCSingle, dst: var T): bool {.inline.} =
   ## Returns true if successful (channel was not empty)
   ##
   ## ⚠ Use only in the consumer thread that reads from the channel.
-  preCondition: (sizeof(T) == chan.itemSize.int) or
-                # Support dummy object
-                (sizeof(T) == 0 and chan.itemSize == 1)
+  static: doAssert supportsCopyMem(T), "Channel is not garbage-collection-safe"
 
-  let full = chan.full.load(moAcquire)
-  if not full:
-    return false
-  dst = cast[ptr T](chan.buffer.addr)[]
-  chan.full.store(false, moRelease)
-  return true
+  case chan.full.load(moAcquire)
+  of true:
+    dst = move(chan.value)
+    chan.full.store(false, moRelease)
+    true
+  of false:
+    false
 
 func trySend*[T](chan: var ChannelSPSCSingle, src: sink T): bool {.inline.} =
   ## Try sending an item into the channel
   ## Reurns true if successful (channel was empty)
   ##
   ## ⚠ Use only in the producer thread that writes from the channel.
-  preCondition: (sizeof(T) == chan.itemSize.int) or
-                # Support dummy object
-                (sizeof(T) == 0 and chan.itemSize == 1)
+  static: doAssert supportsCopyMem(T), "Channel is not garbage-collection-safe"
 
-  let full = chan.full.load(moAcquire)
-  if full:
-    return false
-  cast[ptr T](chan.buffer.addr)[] = src
-  chan.full.store(true, moRelease)
-  return true
+  case chan.full.load(moAcquire)
+  of true:
+    false
+  of false:
+    chan.value = move(src)
+    chan.full.store(true, moRelease)
+    true
 
-{.pop.} # raises: [AssertionDefect]
+{.pop.}
+
 
 # Sanity checks
 # ------------------------------------------------------------------------------
@@ -88,13 +78,13 @@ when isMainModule:
   when not compileOption("threads"):
     {.error: "This requires --threads:on compilation flag".}
 
-  template sendLoop[T](chan: var ChannelSPSCSingle,
+  template sendLoop[T](chan: var ChannelSPSCSingle[T],
                        data: sink T,
                        body: untyped): untyped =
     while not chan.trySend(data):
       body
 
-  template recvLoop[T](chan: var ChannelSPSCSingle,
+  template recvLoop[T](chan: var ChannelSPSCSingle[T],
                        data: var T,
                        body: untyped): untyped =
     while not chan.tryRecv(data):
@@ -103,7 +93,7 @@ when isMainModule:
   type
     ThreadArgs = object
       ID: WorkerKind
-      chan: ptr ChannelSPSCSingle
+      chan: ptr ChannelSPSCSingle[int]
 
     WorkerKind = enum
       Sender
@@ -144,13 +134,14 @@ when isMainModule:
           discard
         echo "Sender sent: ", val
 
+  import primitives/allocs
   proc main() =
     echo "Testing if 2 threads can send data"
     echo "-----------------------------------"
 
     var threads: array[2, Thread[ThreadArgs]]
-    var chan = cast[ptr ChannelSPSCSingle](c_calloc(1, csize_t sizeof(ChannelSPSCSingle)))
-    chan[].initialize(itemSize = sizeof(int))
+    var chan = tp_allocAligned(
+      ChannelSPSCSingle[int], sizeof(ChannelSPSCSingle[int]), 64)
 
     createThread(threads[0], thread_func, ThreadArgs(ID: Receiver, chan: chan))
     createThread(threads[1], thread_func, ThreadArgs(ID: Sender, chan: chan))
@@ -158,7 +149,7 @@ when isMainModule:
     joinThread(threads[0])
     joinThread(threads[1])
 
-    c_free(chan)
+    tp_freeAligned(chan)
 
     echo "-----------------------------------"
     echo "Success"

--- a/taskpools/channels_spsc_single.nim
+++ b/taskpools/channels_spsc_single.nim
@@ -67,8 +67,6 @@ func trySend*[T](chan: var ChannelSPSCSingle, src: sink T): bool {.inline.} =
     chan.full.store(true, moRelease)
     true
 
-{.pop.}
-
 {.pop.} # raises: []
 
 # Sanity checks

--- a/taskpools/channels_spsc_single.nim
+++ b/taskpools/channels_spsc_single.nim
@@ -73,8 +73,6 @@ func trySend*[T](chan: var ChannelSPSCSingle, src: sink T): bool {.inline.} =
 # Sanity checks
 # ------------------------------------------------------------------------------
 when isMainModule:
-  import system/ansi_c
-
   when not compileOption("threads"):
     {.error: "This requires --threads:on compilation flag".}
 
@@ -142,6 +140,7 @@ when isMainModule:
     var threads: array[2, Thread[ThreadArgs]]
     var chan = tp_allocAligned(
       ChannelSPSCSingle[int], sizeof(ChannelSPSCSingle[int]), 64)
+    zeroMem(chan, sizeof(ChannelSPSCSingle[int]))
 
     createThread(threads[0], thread_func, ThreadArgs(ID: Receiver, chan: chan))
     createThread(threads[1], thread_func, ThreadArgs(ID: Sender, chan: chan))

--- a/taskpools/chase_lev_deques.nim
+++ b/taskpools/chase_lev_deques.nim
@@ -1,4 +1,4 @@
-# Nim-Taskpools
+# taskpools
 # Copyright (c) 2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).

--- a/taskpools/event_notifiers.nim
+++ b/taskpools/event_notifiers.nim
@@ -1,4 +1,4 @@
-# Nim-Taskpools
+# taskpools
 # Copyright (c) 2021-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).

--- a/taskpools/flowvars.nim
+++ b/taskpools/flowvars.nim
@@ -1,17 +1,15 @@
-# Weave
+# taskpools
 # Copyright (c) 2019 Mamy André-Ratsimbazafy
+# Copyright (c) 2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  std/os,
   ./instrumentation/contracts,
   ./channels_spsc_single,
   ./primitives/allocs
-
-{.push gcsafe.}
 
 type
   Flowvar*[T] = object
@@ -21,19 +19,19 @@ type
     # instead of having an extra atomic bool
     # They also use type-erasure to avoid having duplicate code
     # due to generic monomorphization.
-    chan: ptr ChannelSPSCSingle
+    chan: ptr ChannelSPSCSingle[T]
 
 # proc `=copy`*[T](dst: var Flowvar[T], src: Flowvar[T]) {.error: "Futures/Flowvars cannot be copied".}
 #
 # Unfortunately we cannot prevent this easily as internally
 # we need a copy:
-# - nim-taskpools level when doing toTask(fnCall(args, fut)) and then returning fut. (Can be worked around with copyMem)
+# - taskpools level when doing toTask(fnCall(args, fut)) and then returning fut. (Can be worked around with copyMem)
 # - in std/tasks (need upstream workaround)
 
 proc newFlowVar*(T: typedesc): Flowvar[T] {.inline.} =
-  let size = 2 + sizeof(T) # full flag + item size + buffer
-  result.chan = tp_allocAligned(ChannelSPSCSingle, size, alignment = 64)
-  result.chan[].initialize(sizeof(T))
+  result.chan = tp_allocAligned(
+    ChannelSPSCSingle[T], sizeof(ChannelSPSCSingle[T]), alignment = 64)
+  zeroMem(result.chan, sizeof(ChannelSPSCSingle[T]))
 
 proc cleanup(fv: Flowvar) {.inline.} =
   # TODO: Nim v1.4+ can use "sink Flowvar"

--- a/taskpools/taskpools.nim
+++ b/taskpools/taskpools.nim
@@ -1,4 +1,4 @@
-# Nim-Taskpools
+# taskpools
 # Copyright (c) 2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).


### PR DESCRIPTION
* flowvar was allocating the wrong size for the spsc channel
* refactor channel to use an ordinary type for its buffer simplifying construction / allocation, remove 256-byte limitation
* fix under-aligned allocation in channel test