### PR TITLE
fix warnings, clean up exceptions a bit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
             cpu: arm64
           - os: windows
             cpu: amd64
-        branch: [version-2-0, version-2-2, devel]
+        branch: [version-1-6, version-2-0, version-2-2, devel]
         include:
           - target:
               os: linux

--- a/taskpools/instrumentation/contracts.nim
+++ b/taskpools/instrumentation/contracts.nim
@@ -81,7 +81,7 @@ macro assertContract(
       "N/A"
   let taskpoolID = quote do:
     when declared(workerContext):
-      "0x" & cast[ByteAddress](workerContext.taskpool).toHex().toLowerAscii()
+      "0x" & cast[uint](workerContext.taskpool).toHex().toLowerAscii()
     else:
       "N/A"
 
@@ -91,7 +91,7 @@ macro assertContract(
         assert(`predicate`, `debug` & $`values` & "  [Worker " & `workerID` & " on taskpool " & `taskpoolID` & "]\n")
       elif defined(TP_Asserts):
         if unlikely(not(`predicate`)):
-          raise newException(AssertionError, `debug` & $`values` & "  [Worker " & `workerID` & " on taskpool " & `taskpoolID` & "]\n")
+          raiseAssert(`debug` & $`values` & "  [Worker " & `workerID` & " on taskpool " & `taskpoolID` & "]\n")
 
 # A way way to get the caller function would be nice.
 

--- a/taskpools/primitives/barriers.nim
+++ b/taskpools/primitives/barriers.nim
@@ -17,7 +17,7 @@ when defined(windows):
   proc init*(syncBarrier: var SyncBarrier, threadCount: range[0'i32..high(int32)]) {.raises: [OSError].} =
     ## Initialize a synchronization barrier that will block ``threadCount`` threads
     ## before release.
-    if InitializeSynchronizationBarrier(syncBarrier, threadCount, -1) == 1:
+    if InitializeSynchronizationBarrier(syncBarrier, threadCount, -1) != 1:
       raiseOSError(osLastError())
 
   proc wait*(syncBarrier: var SyncBarrier): bool =

--- a/taskpools/primitives/barriers.nim
+++ b/taskpools/primitives/barriers.nim
@@ -1,33 +1,32 @@
-# Weave
 # Copyright (c) 2019 Mamy André-Ratsimbazafy
+# Copyright (c) 2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [], gcsafe, inline.}
+
+import os
+
 when defined(windows):
   import ./barriers_windows
-  when compileOption("assertions"):
-    import os
 
   type SyncBarrier* = SynchronizationBarrier
 
-  proc init*(syncBarrier: var SyncBarrier, threadCount: range[0'i32..high(int32)]) {.inline.} =
+  proc init*(syncBarrier: var SyncBarrier, threadCount: range[0'i32..high(int32)]) {.raises: [OSError].} =
     ## Initialize a synchronization barrier that will block ``threadCount`` threads
     ## before release.
-    let err {.used.} = InitializeSynchronizationBarrier(syncBarrier, threadCount, -1)
-    when compileOption("assertions"):
-      if err != 1:
-        assert err == 0
-        raiseOSError(osLastError())
+    if InitializeSynchronizationBarrier(syncBarrier, threadCount, -1) == 1:
+      raiseOSError(osLastError())
 
-  proc wait*(syncBarrier: var SyncBarrier): bool {.inline.} =
+  proc wait*(syncBarrier: var SyncBarrier): bool =
     ## Blocks thread at a synchronization barrier.
     ## Returns true for one of the threads (the last one on Windows, undefined on Posix)
     ## and false for the others.
-    result = bool EnterSynchronizationBarrier(syncBarrier, SYNCHRONIZATION_BARRIER_FLAGS_NO_DELETE)
+    bool EnterSynchronizationBarrier(syncBarrier, SYNCHRONIZATION_BARRIER_FLAGS_NO_DELETE)
 
-  proc delete*(syncBarrier: sink SyncBarrier) {.inline.} =
+  proc delete*(syncBarrier: sink SyncBarrier) =
     ## Deletes a synchronization barrier.
     ## This assumes no race between waiting at a barrier and deleting it,
     ## and reuse of the barrier requires initialization.
@@ -35,35 +34,29 @@ when defined(windows):
 
 else:
   import ./barriers_posix
-  when compileOption("assertions"):
-    import os
 
   type SyncBarrier* = PthreadBarrier
 
-  proc init*(syncBarrier: var SyncBarrier, threadCount: range[0'i32..high(int32)]) {.inline.} =
+  proc init*(syncBarrier: var SyncBarrier, threadCount: range[0'i32..high(int32)]) {.raises: [OSError].} =
     ## Initialize a synchronization barrier that will block ``threadCount`` threads
     ## before release.
-    let err {.used.} = pthread_barrier_init(syncBarrier, nil, cuint threadCount)
-    when compileOption("assertions"):
-      if err != 0:
-        raiseOSError(OSErrorCode(err))
+    let err = pthread_barrier_init(syncBarrier, nil, cuint threadCount)
+    if err != 0:
+      raiseOSError(OSErrorCode(err))
 
-  proc wait*(syncBarrier: var SyncBarrier): bool {.inline.} =
+  proc wait*(syncBarrier: var SyncBarrier): bool =
     ## Blocks thread at a synchronization barrier.
     ## Returns true for one of the threads (the last one on Windows, undefined on Posix)
     ## and false for the others.
-    let err {.used.} = pthread_barrier_wait(syncBarrier)
-    when compileOption("assertions"):
-      if err != PTHREAD_BARRIER_SERIAL_THREAD and err < 0:
-        raiseOSError(OSErrorCode(err))
-    result = if err == PTHREAD_BARRIER_SERIAL_THREAD: true
-             else: false
+    ##
+    # https://pubs.opengroup.org/onlinepubs/009696899/functions/pthread_barrier_wait.html
+    let res = pthread_barrier_wait(syncBarrier)
+    assert res == 0 or res == PTHREAD_BARRIER_SERIAL_THREAD, osErrorMsg(OSErrorCode(res))
+    res == PTHREAD_BARRIER_SERIAL_THREAD
 
-  proc delete*(syncBarrier: sink SyncBarrier) {.inline.} =
+  proc delete*(syncBarrier: sink SyncBarrier) =
     ## Deletes a synchronization barrier.
     ## This assumes no race between waiting at a barrier and deleting it,
     ## and reuse of the barrier requires initialization.
     let err {.used.} = pthread_barrier_destroy(syncBarrier)
-    when compileOption("assertions"):
-      if err < 0:
-        raiseOSError(OSErrorCode(err))
+    assert err == 0, osErrorMsg(OSErrorCode(err))

--- a/taskpools/taskpools.nim
+++ b/taskpools/taskpools.nim
@@ -35,7 +35,7 @@
 # In case a thread is blocked for IO, other threads can steal pending tasks in that thread.
 # If all threads are pending for IO, the threadpool will not make any progress and be soft-locked.
 
-{.push raises: [].} # Ensure no exceptions can happen
+{.push raises: [], gcsafe.} # Ensure no exceptions can happen
 
 import
   system/ansi_c,
@@ -140,10 +140,9 @@ proc teardownWorker() =
   ctx.taskDeque[].teardown()
   ctx.victims.delete()
 
-proc eventLoop(ctx: var WorkerContext) {.raises:[Exception].}
+proc eventLoop(ctx: var WorkerContext) {.raises:[].}
 
-proc workerEntryFn(params: tuple[taskpool: Taskpool, id: WorkerID])
-       {.raises: [Exception].} =
+proc workerEntryFn(params: tuple[taskpool: Taskpool, id: WorkerID]) =
   ## On the start of the threadpool workers will execute this
   ## until they receive a termination signal
   # We assume that thread_local variables start all at their binary zero value
@@ -181,7 +180,7 @@ proc new(T: type TaskNode, parent: TaskNode, task: sink Task): T =
   tn.task = task
   return tn
 
-proc runTask(tn: var TaskNode) {.raises:[], inline.} =
+proc runTask(tn: var TaskNode) {.inline.} =
   ## Run a task and consumes the taskNode
   tn.task.invoke()
   {.gcsafe.}: # Upstream missing tagging `=destroy` as gcsafe
@@ -214,7 +213,7 @@ proc trySteal(ctx: var WorkerContext): TaskNode =
 
   return nil
 
-proc eventLoop(ctx: var WorkerContext) {.raises:[Exception].} =
+proc eventLoop(ctx: var WorkerContext) =
   ## Each worker thread executes this loop over and over.
   while not ctx.signal.terminate.load(moRelaxed):
     # 1. Pick from local deque
@@ -244,7 +243,7 @@ const RootTask = default(Task) # TODO: sentinel value different from null task
 template isRootTask(task: Task): bool =
   task == RootTask
 
-proc forceFuture*[T](fv: Flowvar[T], parentResult: var T) {.raises:[].} =
+proc forceFuture*[T](fv: Flowvar[T], parentResult: var T) =
   ## Eagerly complete an awaited FlowVar
 
   template ctx: untyped = workerContext
@@ -289,7 +288,7 @@ proc forceFuture*[T](fv: Flowvar[T], parentResult: var T) {.raises:[].} =
       # We don't park as there is no notif for task completion
       cpuRelax()
 
-proc syncAll*(tp: Taskpool) {.raises: [Exception].} =
+proc syncAll*(tp: Taskpool) =
   ## Blocks until all pending tasks are completed
   ## This MUST only be called from
   ## the root scope that created the taskpool
@@ -338,7 +337,7 @@ proc syncAll*(tp: Taskpool) {.raises: [Exception].} =
 # Runtime
 # ---------------------------------------------
 
-proc new*(T: type Taskpool, numThreads = countProcessors()): T {.raises: [Exception].} =
+proc new*(T: type Taskpool, numThreads = countProcessors()): T {.raises: [CatchableError].} =
   ## Initialize a threadpool that manages `numThreads` threads.
   ## Default to the number of logical processors available.
 
@@ -374,7 +373,7 @@ proc new*(T: type Taskpool, numThreads = countProcessors()): T {.raises: [Except
   discard tp.barrier.wait()
   return tp
 
-proc cleanup(tp: var Taskpool) {.raises: [AssertionDefect, OSError].} =
+proc cleanup(tp: var Taskpool) =
   ## Cleanup all resources allocated by the taskpool
   preCondition: workerContext.currentTask.task.isRootTask()
 
@@ -389,7 +388,7 @@ proc cleanup(tp: var Taskpool) {.raises: [AssertionDefect, OSError].} =
 
   tp.tp_freeAligned()
 
-proc shutdown*(tp: var Taskpool) {.raises:[Exception].} =
+proc shutdown*(tp: var Taskpool) =
   ## Wait until all tasks are processed and then shutdown the taskpool
   preCondition: workerContext.currentTask.task.isRootTask()
   tp.syncAll()

--- a/taskpools/tasks.nim
+++ b/taskpools/tasks.nim
@@ -53,7 +53,7 @@ when compileOption("threads"):
 # let t = Task(callback: hello_369098781, args: scratch_369098762, destroy: destroyScratch_369098782)
 #
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 type
   Task* = object ## `Task` contains the callback and its arguments.
@@ -64,14 +64,14 @@ type
 
 proc `=copy`*(x: var Task, y: Task) {.error.}
 
-proc `=destroy`*(t: var Task) {.inline, gcsafe.} =
+proc `=destroy`*(t: var Task) {.inline.} =
   ## Frees the resources allocated for a `Task`.
   if t.args != nil:
     if t.destroy != nil:
       t.destroy(t.args)
     c_free(t.args)
 
-proc invoke*(task: Task) {.inline, gcsafe.} =
+proc invoke*(task: Task) {.inline.} =
   ## Invokes the `task`.
   assert task.callback != nil
   task.callback(task.args)


### PR DESCRIPTION
* avoid `Exception` raising effect
* panic on barrier failure onstead of raising OSError - per barrier docs, it should never fail on a correctly initialized barrier
* avoid different exception effects in debug/release mode