### PR TITLE
fix: iOS condition broadcast

### DIFF
--- a/taskpools/primitives/barriers_macos.nim
+++ b/taskpools/primitives/barriers_macos.nim
@@ -30,13 +30,6 @@ type
 const
   PTHREAD_BARRIER_SERIAL_THREAD* = Errno(1)
 
-proc pthread_cond_broadcast(cond: var Cond): Errno {.header:"<pthread.h>".}
-  ## Nim only signal one thread in locks
-  ## We need to unblock all
-
-proc broadcast(cond: var Cond) {.inline.}=
-  discard pthread_cond_broadcast(cond)
-
 func pthread_barrier_init*(
         barrier: var PthreadBarrier,
         attr: ptr PthreadBarrierAttr,


### PR DESCRIPTION
This breaks the `pthread_cond_broadcast` on IOS and the threadpool gets into deadlock on init.

The problem is that there's a workaround for IOS in `syslocks.nim` and the `Cond` is a ptr allocated with malloc (as opposed to macos).

https://github.com/nim-lang/Nim/blob/devel/lib/std/private/syslocks.nim#L208

I don't really understand why we have this custom `pthread_cond_broadcast`. Nim will do exactly the same thing to broadcast.

Tested on IOS and MacOS