### PR TITLE
Fix #6; Support tasks submitted from a thread that is not managed by the threadpool

### DIFF
--- a/benchmarks/injection_queue_starvation/taskpool_iqs.nim
+++ b/benchmarks/injection_queue_starvation/taskpool_iqs.nim
@@ -1,0 +1,175 @@
+import
+  # STD lib
+  os, strutils, system/ansi_c, cpuinfo, strformat, math, atomics,
+  # Library
+  ../../taskpools,
+  # bench
+  ../wtime, ../resources
+
+# Benchmark: Injection Queue Starvation (IQS)
+#
+# Known caveat: the MPMC injection queue (used when external threads call spawn)
+# is drained by workers ONLY when their local Chase-Lev deque is empty.
+#
+# If tasks spawned from within the pool continuously refill local deques,
+# external tasks pile up in the injection queue and are never consumed
+# until all internal spawning stops and deques finally drain.
+#
+# This benchmark triggers the condition by running two concurrent workloads:
+#
+#   INTERNAL: the main pool worker spawns a binary tree of depth D
+#             (2^(D+1)-1 tasks). Each internal task calls tp.spawn from
+#             within a pool thread -> schedule() -> local Chase-Lev deque.
+#             Workers stay perpetually busy at step 1.
+#
+#   EXTERNAL: NumExtThreads non-pool threads concurrently call tp.spawn,
+#             which calls submitTask() -> injection queue (Treiber stack).
+#             These tasks cannot be drained while deques are full.
+#
+# Key metric: starvation window
+#   = T_all_done - T_submit_end
+#   = time between "all external tasks submitted" and "syncAll() returns"
+#
+# A large starvation window means external tasks sat queued while the pool
+# was busy with internal work. A small one means the injection queue was
+# drained promptly alongside internal work.
+
+var InternalDepth: int32    # binary-tree depth; internal tasks = 2^(D+1)-1
+var NumExtThreads: int      # external (non-pool) producer threads
+var NumTasksPerExtThread: int  # tasks each external thread submits
+
+var tp: Taskpool
+var externalCompleted: Atomic[int]
+
+template dummy_cpt(): untyped =
+  # Minimal CPU burn so tasks are not zero-cost (helps keep deques non-empty)
+  var fib = 0
+  var f2 = 0
+  var f1 = 1
+  for i in 2 .. 30:
+    fib = f1 + f2
+    f2 = f1
+    f1 = fib
+
+# Spawned from within pool workers -> goes to local Chase-Lev deque via schedule().
+# Continuously refills deques, preventing workers from ever reaching
+# drainInjectionQueue() while the tree is alive.
+proc internalSpawn(depth: int32) {.gcsafe, raises: [].} =
+  if depth > 0:
+    tp.spawn internalSpawn(depth - 1)
+    tp.spawn internalSpawn(depth - 1)
+  dummy_cpt()
+
+# Submitted from external threads -> goes to injection queue via submitTask().
+# Starved until all internal work has drained the local deques.
+proc externalTask() {.gcsafe, raises: [].} =
+  dummy_cpt()
+  discard externalCompleted.fetchAdd(1, moRelaxed)
+
+proc externalProducer() {.thread.} =
+  for _ in 0 ..< NumTasksPerExtThread:
+    tp.spawn externalTask()
+
+proc main() =
+  InternalDepth = 20          # 2^21 - 1 ~ 2 M internal tasks
+  NumExtThreads = 16
+  NumTasksPerExtThread = 10000
+
+  if paramCount() == 0:
+    let exeName = getAppFilename().extractFilename()
+    echo &"Usage: {exeName} <internal tree depth: {InternalDepth}> " &
+         &"<# of external threads: {NumExtThreads}> " &
+         &"<tasks per external thread: {NumTasksPerExtThread}>"
+    echo &"Running with defaults: depth={InternalDepth}, " &
+         &"extThreads={NumExtThreads}, tasksPerThread={NumTasksPerExtThread}"
+  if paramCount() >= 1:
+    InternalDepth = paramStr(1).parseInt().int32
+  if paramCount() >= 2:
+    NumExtThreads = paramStr(2).parseInt()
+  if paramCount() >= 3:
+    NumTasksPerExtThread = paramStr(3).parseInt()
+  if paramCount() > 3:
+    let exeName = getAppFilename().extractFilename()
+    echo &"Usage: {exeName} <internal tree depth: {InternalDepth}> " &
+         &"<# of external threads: {NumExtThreads}> " &
+         &"<tasks per external thread: {NumTasksPerExtThread}>"
+    quit 1
+
+  let numExtTasksTotal = NumExtThreads * NumTasksPerExtThread
+  let numInternalTasksTotal = (1 shl (InternalDepth + 1)) - 1
+
+  var nthreads: int
+  if existsEnv"TASKPOOL_NUM_THREADS":
+    nthreads = getEnv"TASKPOOL_NUM_THREADS".parseInt()
+  else:
+    nthreads = countProcessors()
+
+  externalCompleted.store(0, moRelaxed)
+  tp = Taskpool.new(numThreads = nthreads)
+
+  var ru: Rusage
+  getrusage(RusageSelf, ru)
+  var
+    rss = ru.ru_maxrss
+    flt = ru.ru_minflt
+
+  let start = wtime_msec()
+
+  # Kick off the internal tree from the root pool worker.
+  # This immediately starts filling local deques of all workers.
+  tp.spawn internalSpawn(InternalDepth)
+
+  # Launch external producers right after.
+  # They will compete with the internal tree for injection queue drain time.
+  var extThreads = newSeq[Thread[void]](NumExtThreads)
+  for t in extThreads.mitems():
+    createThread(t, externalProducer)
+  for t in extThreads:
+    joinThread(t)
+
+  # All external tasks are now in the injection queue (or already consumed).
+  let submitEnd = wtime_msec()
+
+  # Wait for all work — internal tree + external tasks — to complete.
+  tp.syncAll()
+
+  let allDone = wtime_msec()
+
+  getrusage(RusageSelf, ru)
+  rss = ru.ru_maxrss - rss
+  flt = ru.ru_minflt - flt
+
+  tp.shutdown()
+
+  let got = externalCompleted.load(moRelaxed)
+  doAssert got == numExtTasksTotal,
+    &"Expected {numExtTasksTotal} external tasks completed, got {got}"
+
+  let totalMs       = round(allDone - start, 3)
+  let submissionMs  = round(submitEnd - start, 3)
+  let starvationMs  = round(allDone - submitEnd, 3)
+
+  echo "--------------------------------------------------------------------------"
+  echo "Scheduler:                                     Taskpool"
+  echo "Benchmark:                                     IQS (Injection Queue Starvation)"
+  echo "Pool threads:                                  ", nthreads
+  echo "External producer threads:                     ", NumExtThreads
+  echo "Time total (ms):                               ", totalMs
+  echo "Max RSS (KB):                                  ", ru.ru_maxrss
+  echo "Runtime RSS (KB):                              ", rss
+  echo "# of page faults:                              ", flt
+  echo "--------------------------------------------------------------------------"
+  echo "Internal tree depth:                           ", InternalDepth
+  echo "Internal tasks (2^(D+1)-1):                   ", numInternalTasksTotal
+  echo "External tasks total:                          ", numExtTasksTotal
+  echo "External tasks per thread:                     ", NumTasksPerExtThread
+  echo "--------------------------------------------------------------------------"
+  echo "External submission wall time (ms):            ", submissionMs
+  echo "Starvation window (ms):                        ", starvationMs
+  echo "  (time between last external submit and syncAll returning)"
+  echo "  A large value means external tasks were starved in the injection queue"
+  echo "  while pool workers were busy processing internal spawns."
+
+  quit 0
+
+main()

--- a/benchmarks/iqs_latency/taskpool_iqs_latency.nim
+++ b/benchmarks/iqs_latency/taskpool_iqs_latency.nim
@@ -1,45 +1,45 @@
 import
-  # STD lib
-  os, strutils, system/ansi_c, cpuinfo, strformat, math, atomics,
-  # Library
+  os, strutils, cpuinfo, strformat, math, atomics,
   ../../taskpools,
-  # bench
-  ../wtime, ../resources
+  ../wtime
 
-# Benchmark: Injection Queue Starvation (IQS)
+# Benchmark: Injection Queue Starvation (IQS) - external-task latency
 #
-# Known caveat: the MPMC injection queue (used when external threads call spawn)
-# is drained by workers ONLY when their local Chase-Lev deque is empty.
+# The MPMC injection queue (used when external threads call spawn) is drained
+# by workers between local tasks. If tasks spawned from within the pool
+# continuously refill the local Chase-Lev deques, externally submitted tasks
+# can pile up in the injection queue and be consumed only slowly.
 #
-# If tasks spawned from within the pool continuously refill local deques,
-# external tasks pile up in the injection queue and are never consumed
-# until all internal spawning stops and deques finally drain.
+# This benchmark runs two concurrent workloads:
 #
-# This benchmark triggers the condition by running two concurrent workloads:
+#   INTERNAL: the root pool worker spawns a binary tree of depth D
+#             (2^(D+1)-1 tasks). Each internal task calls tp.spawn from within
+#             a pool thread -> schedule() -> local Chase-Lev deque, keeping the
+#             workers perpetually busy on local work.
 #
-#   INTERNAL: the main pool worker spawns a binary tree of depth D
-#             (2^(D+1)-1 tasks). Each internal task calls tp.spawn from
-#             within a pool thread -> schedule() -> local Chase-Lev deque.
-#             Workers stay perpetually busy at step 1.
+#   EXTERNAL: NumExtThreads non-pool threads concurrently call tp.spawn, which
+#             calls submitTask() -> injection queue (Treiber stack).
 #
-#   EXTERNAL: NumExtThreads non-pool threads concurrently call tp.spawn,
-#             which calls submitTask() -> injection queue (Treiber stack).
-#             These tasks cannot be drained while deques are full.
+# Key metric: external-task latency
+#   = T_last_external_done - T_submit_end
+#   = wall time between "all external tasks submitted" and "the last external
+#     task actually completed".
 #
-# Key metric: starvation window
-#   = T_all_done - T_submit_end
-#   = time between "all external tasks submitted" and "syncAll() returns"
-#
-# A large starvation window means external tasks sat queued while the pool
-# was busy with internal work. A small one means the injection queue was
-# drained promptly alongside internal work.
+# Unlike a "starvation window" measured against syncAll() (which is bound by
+# the TOTAL workload, since syncAll waits for everything), this isolates how
+# long externally injected tasks sit unconsumed while workers churn through a
+# continuously refilled local deque. A large value means external tasks were
+# starved; a small value means the injection queue was drained promptly.
 
-var InternalDepth: int32    # binary-tree depth; internal tasks = 2^(D+1)-1
-var NumExtThreads: int      # external (non-pool) producer threads
+var InternalDepth: int32       # binary-tree depth; internal tasks = 2^(D+1)-1
+var NumExtThreads: int         # external (non-pool) producer threads
 var NumTasksPerExtThread: int  # tasks each external thread submits
 
 var tp: Taskpool
 var externalCompleted: Atomic[int]
+var numExtTasksTotal: int
+var submitEndMs: float64
+var lastExtDoneMs: Atomic[int]  # msec*1000 stored as int for atomicity
 
 template dummy_cpt(): untyped =
   # Minimal CPU burn so tasks are not zero-cost (helps keep deques non-empty)
@@ -52,8 +52,7 @@ template dummy_cpt(): untyped =
     f1 = fib
 
 # Spawned from within pool workers -> goes to local Chase-Lev deque via schedule().
-# Continuously refills deques, preventing workers from ever reaching
-# drainInjectionQueue() while the tree is alive.
+# Continuously refills deques, keeping workers busy on local work.
 proc internalSpawn(depth: int32) {.gcsafe, raises: [].} =
   if depth > 0:
     tp.spawn internalSpawn(depth - 1)
@@ -61,10 +60,12 @@ proc internalSpawn(depth: int32) {.gcsafe, raises: [].} =
   dummy_cpt()
 
 # Submitted from external threads -> goes to injection queue via submitTask().
-# Starved until all internal work has drained the local deques.
+# The last one to complete records the timestamp used for the latency metric.
 proc externalTask() {.gcsafe, raises: [].} =
   dummy_cpt()
-  discard externalCompleted.fetchAdd(1, moRelaxed)
+  let n = externalCompleted.fetchAdd(1, moRelaxed) + 1
+  if n == numExtTasksTotal:
+    lastExtDoneMs.store(int(wtime_msec() * 1000), moRelaxed)
 
 proc externalProducer() {.thread.} =
   for _ in 0 ..< NumTasksPerExtThread:
@@ -95,7 +96,7 @@ proc main() =
          &"<tasks per external thread: {NumTasksPerExtThread}>"
     quit 1
 
-  let numExtTasksTotal = NumExtThreads * NumTasksPerExtThread
+  numExtTasksTotal = NumExtThreads * NumTasksPerExtThread
   let numInternalTasksTotal = (1 shl (InternalDepth + 1)) - 1
 
   var nthreads: int
@@ -105,39 +106,29 @@ proc main() =
     nthreads = countProcessors()
 
   externalCompleted.store(0, moRelaxed)
+  lastExtDoneMs.store(0, moRelaxed)
   tp = Taskpool.new(numThreads = nthreads)
-
-  var ru: Rusage
-  getrusage(RusageSelf, ru)
-  var
-    rss = ru.ru_maxrss
-    flt = ru.ru_minflt
 
   let start = wtime_msec()
 
-  # Kick off the internal tree from the root pool worker.
-  # This immediately starts filling local deques of all workers.
+  # Kick off the internal tree from the root pool worker; this immediately
+  # starts filling the local deques of all workers.
   tp.spawn internalSpawn(InternalDepth)
 
-  # Launch external producers right after.
-  # They will compete with the internal tree for injection queue drain time.
+  # Launch external producers right after; they compete with the internal tree
+  # for injection queue drain time.
   var extThreads = newSeq[Thread[void]](NumExtThreads)
   for t in extThreads.mitems():
     createThread(t, externalProducer)
   for t in extThreads:
     joinThread(t)
 
-  # All external tasks are now in the injection queue (or already consumed).
-  let submitEnd = wtime_msec()
+  # All external tasks are now submitted (in the injection queue or consumed).
+  submitEndMs = wtime_msec()
 
   # Wait for all work — internal tree + external tasks — to complete.
   tp.syncAll()
-
   let allDone = wtime_msec()
-
-  getrusage(RusageSelf, ru)
-  rss = ru.ru_maxrss - rss
-  flt = ru.ru_minflt - flt
 
   tp.shutdown()
 
@@ -145,9 +136,10 @@ proc main() =
   doAssert got == numExtTasksTotal,
     &"Expected {numExtTasksTotal} external tasks completed, got {got}"
 
+  let lastExtDone   = lastExtDoneMs.load(moRelaxed).float64 / 1000.0
+  let extLatencyMs  = round(lastExtDone - submitEndMs, 3)
   let totalMs       = round(allDone - start, 3)
-  let submissionMs  = round(submitEnd - start, 3)
-  let starvationMs  = round(allDone - submitEnd, 3)
+  let submissionMs  = round(submitEndMs - start, 3)
 
   echo "--------------------------------------------------------------------------"
   echo "Scheduler:                                     Taskpool"
@@ -155,18 +147,15 @@ proc main() =
   echo "Pool threads:                                  ", nthreads
   echo "External producer threads:                     ", NumExtThreads
   echo "Time total (ms):                               ", totalMs
-  echo "Max RSS (KB):                                  ", ru.ru_maxrss
-  echo "Runtime RSS (KB):                              ", rss
-  echo "# of page faults:                              ", flt
   echo "--------------------------------------------------------------------------"
   echo "Internal tree depth:                           ", InternalDepth
-  echo "Internal tasks (2^(D+1)-1):                   ", numInternalTasksTotal
+  echo "Internal tasks (2^(D+1)-1):                    ", numInternalTasksTotal
   echo "External tasks total:                          ", numExtTasksTotal
   echo "External tasks per thread:                     ", NumTasksPerExtThread
   echo "--------------------------------------------------------------------------"
   echo "External submission wall time (ms):            ", submissionMs
-  echo "Starvation window (ms):                        ", starvationMs
-  echo "  (time between last external submit and syncAll returning)"
+  echo "External task latency (ms):                    ", extLatencyMs
+  echo "  (time between last external submit and the last external task done)"
   echo "  A large value means external tasks were starved in the injection queue"
   echo "  while pool workers were busy processing internal spawns."
 

--- a/benchmarks/single_task_producer/taskpool_spc_external.nim
+++ b/benchmarks/single_task_producer/taskpool_spc_external.nim
@@ -1,0 +1,113 @@
+import
+  # STD lib
+  os, strutils, system/ansi_c, cpuinfo, strformat, math,
+  # Library
+  ../../taskpools,
+  # bench
+  ../wtime, ../resources
+
+# External-thread variant of the SPC (Single task Producer - multi Consumer) benchmark.
+
+var NumTasksTotal: int32
+var TaskGranularity: int32 # microsecond
+var PollInterval: float64  # microsecond
+
+var tp: Taskpool
+
+var global_poll_elapsed {.threadvar.}: float64
+
+template dummy_cpt(): untyped =
+  var
+    fib = 0
+    f2 = 0
+    f1 = 1
+  for i in 2 .. 30:
+    fib = f1 + f2
+    f2 = f1
+    f1 = fib
+
+proc spc_consume(usec: int32) {.gcsafe, raises: [].} =
+  let start = wtime_usec()
+  let stop = usec.float64
+  while true:
+    let elapsed = wtime_usec() - start
+    if elapsed >= stop:
+      break
+    dummy_cpt()
+
+proc spc_produce(n: int32) {.thread.} =
+  for i in 0 ..< n:
+    tp.spawn spc_consume(TaskGranularity)
+
+proc main() =
+  NumTasksTotal = 1000000
+  TaskGranularity = 10
+  PollInterval = 10
+
+  if paramCount() == 0:
+    let exeName = getAppFilename().extractFilename()
+    echo &"Usage: {exeName} <# of tasks:{NumTasksTotal}> " &
+         &"<task granularity (us): {TaskGranularity}> " &
+         &"[polling interval (us): task granularity]"
+    echo &"Running with default config tasks = {NumTasksTotal}, granularity (us) = {TaskGranularity}, polling (us) = {PollInterval}"
+  if paramCount() >= 1:
+    NumTasksTotal = paramStr(1).parseInt.int32
+  if paramCount() >= 2:
+    TaskGranularity = paramStr(2).parseInt.int32
+  if paramCount() == 3:
+    PollInterval = paramStr(3).parseInt.float64
+  else:
+    PollInterval = TaskGranularity.float64
+  if paramCount() > 3:
+    let exeName = getAppFilename().extractFilename()
+    echo &"Usage: {exeName} <# of tasks:{NumTasksTotal}> " &
+         &"<task granularity (us): {TaskGranularity}> " &
+         &"[polling interval (us): task granularity]"
+    quit 1
+
+  var nthreads: int
+  if existsEnv"TP_NUM_THREADS":
+    nthreads = getEnv"TP_NUM_THREADS".parseInt()
+  else:
+    nthreads = countProcessors()
+
+  tp = Taskpool.new(numThreads = nthreads)
+
+  var ru: Rusage
+  getrusage(RusageSelf, ru)
+  var
+    rss = ru.ru_maxrss
+    flt = ru.ru_minflt
+
+  let start = wtime_msec()
+
+  var producer: Thread[int32]
+  createThread(producer, spc_produce, NumTasksTotal)
+  joinThread(producer)
+
+  tp.syncAll()
+
+  let stop = wtime_msec()
+
+  getrusage(RusageSelf, ru)
+  rss = ru.ru_maxrss - rss
+  flt = ru.ru_minflt - flt
+
+  tp.shutdown()
+
+  echo "--------------------------------------------------------------------------"
+  echo "Scheduler:                                     Taskpool"
+  echo "Benchmark:                                     SPC external (Single task Producer - multi Consumer)"
+  echo "Threads:                                       ", nthreads
+  echo "Time(ms)                                       ", round(stop - start, 3)
+  echo "Max RSS (KB):                                  ", ru.ru_maxrss
+  echo "Runtime RSS (KB):                              ", rss
+  echo "# of page faults:                              ", flt
+  echo "--------------------------------------------------------------------------"
+  echo "# of tasks:                                    ", NumTasksTotal
+  echo "Task granularity (us):                         ", TaskGranularity
+  echo "Polling / manual load balancing interval (us): ", PollInterval
+
+  quit 0
+
+main()

--- a/examples/e03_external_threads.nim
+++ b/examples/e03_external_threads.nim
@@ -1,0 +1,31 @@
+import std/atomics
+import ../taskpools
+
+block:
+  var counter: Atomic[int]
+  counter.store(0, moRelaxed)
+
+  var tp = Taskpool.new(numThreads = 4)
+
+  proc increment() {.gcsafe, raises: [].} =
+    discard counter.fetchAdd(1, moRelaxed)
+
+  proc worker() {.thread.} =
+    for _ in 0 ..< 1000:
+      tp.spawn(increment())
+
+  proc main() =
+    echo "\nThread worker count"
+
+    let workers = 16
+    var threads = newSeq[Thread[void]](workers)
+    for t in threads.mitems():
+      createThread(t, worker)
+    for t in threads:
+      joinThread(t)
+    tp.shutdown()
+    let got = counter.load(moRelaxed)
+    echo "Got: " & $got
+    doAssert got == workers * 1000
+
+  main()

--- a/taskpools.nimble
+++ b/taskpools.nimble
@@ -44,6 +44,7 @@ proc runTests(args: string) =
   # Examples
   run args, "examples/e01_simple_tasks.nim"
   run args, "examples/e02_parallel_pi.nim"
+  run args, "examples/e03_external_threads.nim"
 
   # Tests
   run args, "tests/test_all.nim"

--- a/taskpools.nimble
+++ b/taskpools.nimble
@@ -57,6 +57,7 @@ proc runBenchs(args: string) =
   run args, "benchmarks/dfs/taskpool_dfs.nim"
   run args, "benchmarks/heat/taskpool_heat.nim"
   run args, "benchmarks/nqueens/taskpool_nqueens.nim"
+  run args, "benchmarks/iqs_latency/taskpool_iqs_latency.nim"
 
   when not defined(windows):
     run args, "benchmarks/single_task_producer/taskpool_spc.nim"

--- a/taskpools/flowvars.nim
+++ b/taskpools/flowvars.nim
@@ -64,9 +64,9 @@ func isReady*[T](fv: Flowvar[T]): bool {.inline.} =
   not fv.chan[].isEmpty()
 
 proc sync*[T](fv: sink Flowvar[T]): T {.inline, gcsafe.} =
-  ## Blocks the current thread until the flowvar is available
-  ## and returned.
-  ## The thread is not idle and will complete pending tasks.
+  ## Blocks the current thread until the flowvar is available and returned.
+  ## Worker threads help execute pending tasks while waiting.
+  ## Non-worker (external) threads busy-wait instead.
   mixin forceFuture
   forceFuture(fv, result)
   cleanup(fv)

--- a/taskpools/injection_queues.nim
+++ b/taskpools/injection_queues.nim
@@ -1,0 +1,83 @@
+# taskpools
+# Copyright (c) 2021-2025 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+# Injection queue
+#
+# Lock-free MPMC queue used by threads that are not currently running the
+# taskpool scheduler (external threads, or a worker submitting to a foreign
+# pool) to hand tasks over to the pool's workers.
+#
+# It is a Treiber stack:
+#   - push is lock-free and multi-producer (a release CAS on the head),
+#   - drain claims the whole stack in a single atomic exchange, so only one
+#     worker wins per drain and no per-node synchronization is needed.
+#
+# The nodes are linked intrusively: the element type `T` must be a pointer type
+# whose object has a public `injectionNext: T` field, used as the link. This
+# avoids a separate allocation for the queue links.
+
+{.push raises: [], gcsafe.}
+
+import std/atomics
+
+const TasksBetweenInjectionDrains* {.intdefine: "taskpoolsIqDrainTick".} = 61
+  ## Drain the injection queue after processing at most this many local tasks,
+  ## so externally submitted tasks are not starved while a worker churns through
+  ## a local deque that internal spawns keep refilling. Prime to avoid resonance
+  ## with regular workload sizes. Override with `-d:taskpoolsIqDrainTick:N`.
+
+static:
+  doAssert TasksBetweenInjectionDrains > 0,
+    "taskpoolsIqDrainTick must be a positive integer"
+
+type
+  InjectionQueue*[T] = object
+    ## Lock-free MPMC injection queue (Treiber stack).
+    ## Any thread may push; any worker may drain via atomic exchange;
+    ## only one worker wins the exchange per drain call.
+    head{.align: 64.}: Atomic[T]
+
+proc `=copy`[T](
+    dest: var InjectionQueue[T], source: InjectionQueue[T]
+  ) {.error: "An injection queue cannot be copied".}
+
+proc init*[T](q: var InjectionQueue[T]) {.inline.} =
+  ## Reset the queue to empty. Must be called before any push/drain.
+  q.head.store(default(T), moRelaxed)
+
+func isEmpty*[T](q: var InjectionQueue[T]): bool {.inline.} =
+  ## Racy emptiness check; only a hint outside the draining worker.
+  q.head.load(moRelaxed).isNil
+
+proc push*[T](q: var InjectionQueue[T], node: T) {.inline.} =
+  ## Push a node onto the queue from any thread (lock-free MPMC).
+  ##
+  ## The release CAS on the head makes the plain write to the intrusive link
+  ## visible to the draining worker after its acquire exchange.
+  var headOld = q.head.load(moRelaxed)
+  while true:
+    node.injectionNext = headOld  # plain write; ordered by the release CAS below
+    if q.head.compareExchange(headOld, node, moRelease, moRelaxed):
+      break
+
+iterator drain*[T](q: var InjectionQueue[T]): T {.inline.} =
+  ## Atomically claim the entire queue and yield every node in it, clearing the
+  ## intrusive link of each as it is handed out. Only one caller wins the
+  ## exchange; concurrent callers observe an empty queue and yield nothing.
+  ##
+  ## The acquire exchange orders the plain reads of the intrusive links below
+  ## against the release pushes that produced them.
+  if not q.head.load(moRelaxed).isNil:
+    var node = q.head.exchange(default(T), moAcquire)
+    var next = default(T)
+    while not node.isNil:
+      next = node.injectionNext  # plain read; ordered by the acquire exchange above
+      node.injectionNext = default(T)
+      yield node
+      node = next
+
+{.pop.} # raises: [], gcsafe

--- a/taskpools/injection_queues.nim
+++ b/taskpools/injection_queues.nim
@@ -49,10 +49,6 @@ proc init*[T](q: var InjectionQueue[T]) {.inline.} =
   ## Reset the queue to empty. Must be called before any push/drain.
   q.head.store(default(T), moRelaxed)
 
-func isEmpty*[T](q: var InjectionQueue[T]): bool {.inline.} =
-  ## Racy emptiness check; only a hint outside the draining worker.
-  q.head.load(moRelaxed).isNil
-
 proc push*[T](q: var InjectionQueue[T], node: T) {.inline.} =
   ## Push a node onto the queue from any thread (lock-free MPMC).
   ##
@@ -71,6 +67,9 @@ iterator drain*[T](q: var InjectionQueue[T]): T {.inline.} =
   ##
   ## The acquire exchange orders the plain reads of the intrusive links below
   ## against the release pushes that produced them.
+  # The queue is empty most of the time, so probe with a cheap
+  # relaxed load and take the atomic exchange only when there may be work;
+  # the load(relaxed)+exchange(acquire) race is harmless.
   if not q.head.load(moRelaxed).isNil:
     var node = q.head.exchange(default(T), moAcquire)
     var next = default(T)

--- a/taskpools/taskpools.nim
+++ b/taskpools/taskpools.nim
@@ -232,6 +232,12 @@ proc submitTask(tp: Taskpool, tn: TaskNode) {.inline.} =
       break
   tp.eventNotifier.notify()
 
+const TasksBetweenInjectionDrains = 61
+  ## Drain the injection queue after processing at most this many local tasks,
+  ## so externally submitted tasks are not starved while a worker churns through
+  ## a local deque that internal spawns keep refilling. Prime to avoid resonance
+  ## with regular workload sizes.
+
 proc drainInjectionQueue(ctx: var WorkerContext) {.inline.} =
   ## Atomically claim the entire injection queue and push all tasks into
   ## the calling worker's Chase-Lev deque, where they become stealable.
@@ -278,9 +284,14 @@ proc eventLoop(ctx: var WorkerContext) =
   while not ctx.signal.terminate.load(moRelaxed):
     # 1. Pick from local deque
     debug: log("Worker %2d: eventLoop 1 - searching task from local deque\n", ctx.id)
+    var processed = 0'u32
     while (var taskNode = ctx.taskDeque[].pop(); not taskNode.isNil):
       debug: log("Worker %2d: eventLoop 1 - running task 0x%.08x (parent 0x%.08x, current 0x%.08x)\n", ctx.id, taskNode, taskNode.parent, ctx.currentTask)
       taskNode.runTask()
+      inc processed
+      if processed >= TasksBetweenInjectionDrains:
+        processed = 0
+        ctx.drainInjectionQueue()
 
     # 2. Drain the injection queue into our Chase-Lev deque so externally submitted
     #    tasks become local work (and stealable by other workers).

--- a/taskpools/taskpools.nim
+++ b/taskpools/taskpools.nim
@@ -62,6 +62,9 @@ type
     parent: TaskNode
     callback*: TaskCallback
     args*: pointer
+    # intrusive link for the injection queue;
+    # ordering is guaranteed by release/acquire on injectionQueue
+    injectionNext: TaskNode
 
   Signal = object
     terminate {.align: 64.}: Atomic[bool]
@@ -100,6 +103,11 @@ type
     workers: ptr UncheckedArray[Thread[(Taskpool, WorkerID)]]
     workerSignals: ptr UncheckedArray[Signal]
       ## Access signaledTerminate
+
+    injectionQueue {.align: 64.}: Atomic[TaskNode]
+      ## Lock-free MPMC injection queue (Treiber stack).
+      ## Any thread may push; any worker may drain via atomic exchange;
+      ## only one worker wins the exchange per drain call.
 
 when not sharedHeap:
   proc supportsThreadMove*(T: type): bool {.compileTime.} =
@@ -210,6 +218,41 @@ proc schedule(ctx: WorkerContext, tn: sink TaskNode) {.inline.} =
   ctx.taskDeque[].push(tn)
   ctx.taskpool.eventNotifier.notify()
 
+proc submitTask(tp: Taskpool, tn: TaskNode) {.inline.} =
+  ## Push a task onto the injection queue from any thread.
+  ## Workers will drain the queue into their Chase-Lev deques, making tasks stealable.
+  ##
+  ## Uses a Treiber stack (lock-free MPMC push, single-winner drain via exchange).
+  ## The release CAS on injectionQueue makes the plain write to tn.injectionNext
+  ## visible to the draining worker after its acquire exchange.
+  var headOld = tp.injectionQueue.load(moRelaxed)
+  while true:
+    tn.injectionNext = headOld  # plain write; ordered by the release CAS below
+    if tp.injectionQueue.compareExchange(headOld, tn, moRelease, moRelaxed):
+      break
+  tp.eventNotifier.notify()
+
+proc drainInjectionQueue(ctx: var WorkerContext) {.inline.} =
+  ## Atomically claim the entire injection queue and push all tasks into
+  ## the calling worker's Chase-Lev deque, where they become stealable.
+  ## Only one worker wins the exchange; the others get nil and return immediately.
+  if ctx.taskpool.injectionQueue.load(moRelaxed).isNil:
+    return
+  var node = ctx.taskpool.injectionQueue.exchange(nil, moAcquire)
+  if node.isNil:
+    return
+  var count = 0
+  while not node.isNil:
+    let next = node.injectionNext  # plain read; ordered by the acquire exchange above
+    node.injectionNext = nil
+    ctx.taskDeque[].push(node)
+    node = next
+    inc count
+  # Wake workers so the newly stealable tasks get parallel attention.
+  let toWake = min(count, ctx.taskpool.eventNotifier.getParked())
+  for _ in 0 ..< toWake:
+    ctx.taskpool.eventNotifier.notify()
+
 # Scheduler
 # ---------------------------------------------
 
@@ -239,18 +282,30 @@ proc eventLoop(ctx: var WorkerContext) =
       debug: log("Worker %2d: eventLoop 1 - running task 0x%.08x (parent 0x%.08x, current 0x%.08x)\n", ctx.id, taskNode, taskNode.parent, ctx.currentTask)
       taskNode.runTask()
 
-    # 2. Run out of tasks, become a thief
-    debug: log("Worker %2d: eventLoop 2 - becoming a thief\n", ctx.id)
+    # 2. Drain the injection queue into our Chase-Lev deque so externally submitted
+    #    tasks become local work (and stealable by other workers).
+    ctx.drainInjectionQueue()
+
+    # 3. Re-check local deque; it may now contain injected tasks.
+    var taskNode = ctx.taskDeque[].pop()
+    if not taskNode.isNil:
+      debug: log("Worker %2d: eventLoop 3 - running injected task 0x%.08x\n", ctx.id, taskNode)
+      taskNode.runTask()
+      continue # back to step 1
+
+    # 4. Run out of tasks, become a thief
+    debug: log("Worker %2d: eventLoop 4 - becoming a thief\n", ctx.id)
     var stolenTask = ctx.trySteal()
     if not stolenTask.isNil:
-      # 2.a Run task
-      debug: log("Worker %2d: eventLoop 2.a - stole task 0x%.08x (parent 0x%.08x, current 0x%.08x)\n", ctx.id, stolenTask, stolenTask.parent, ctx.currentTask)
+      # 4.a Run stolen task
+      debug: log("Worker %2d: eventLoop 4.a - stole task 0x%.08x (parent 0x%.08x, current 0x%.08x)\n", ctx.id, stolenTask, stolenTask.parent, ctx.currentTask)
       stolenTask.runTask()
     else:
-      # 2.b Park the thread until a new task enters the taskpool
-      debug: log("Worker %2d: eventLoop 2.b - sleeping\n", ctx.id)
+      # 4.b Park the thread until a new task enters the taskpool.
+      #     submitTask calls notify() so parked workers wake when work arrives.
+      debug: log("Worker %2d: eventLoop 4.b - sleeping\n", ctx.id)
       ctx.eventNotifier[].park()
-      debug: log("Worker %2d: eventLoop 2.b - waking\n", ctx.id)
+      debug: log("Worker %2d: eventLoop 4.b - waking\n", ctx.id)
 
 # Tasking
 # ---------------------------------------------
@@ -270,6 +325,13 @@ proc forceFuture*[T](fv: Flowvar[T], parentResult: var T) =
     fv.chan[].tryRecv(parentResult)
 
   if isFutReady():
+    return
+
+  # External thread: no Chase-Lev deque and no steal peers available.
+  # Busy-wait while pool workers make progress on the task.
+  if ctx.taskpool.isNil:
+    while not isFutReady():
+      cpuRelax()
     return
 
   ## 1. Process all the children of the current tasks.
@@ -307,9 +369,13 @@ proc forceFuture*[T](fv: Flowvar[T], parentResult: var T) =
       cpuRelax()
 
 proc syncAll*(tp: Taskpool) =
-  ## Blocks until all pending tasks are completed
-  ## This MUST only be called from
-  ## the root scope that created the taskpool
+  ## Blocks until all pending tasks are completed.
+  ## This MUST only be called from the root scope that created the taskpool.
+  ##
+  ## All external threads MUST stop calling spawn before syncAll is called.
+  ## There is an inherent race between the termination check and the injection
+  ## queue: a task pushed after syncAll begins its final drain may not be
+  ## waited for.
   template ctx: untyped = workerContext
 
   debugTermination:
@@ -327,26 +393,36 @@ proc syncAll*(tp: Taskpool) =
       debug: log("Worker %2d: syncAll 1 - running task 0x%.08x (parent 0x%.08x, current 0x%.08x)\n", ctx.id, taskNode, taskNode.parent, ctx.currentTask)
       taskNode.runTask()
 
+    # 2. Drain injection queue into local deque so externally submitted tasks
+    #    are not left stranded while we wait for the pool to go idle.
+    ctx.drainInjectionQueue()
+
+    # 3. Re-check local deque; it may now contain injected tasks.
+    if (var taskNode = ctx.taskDeque[].pop(); not taskNode.isNil):
+      debug: log("Worker %2d: syncAll 3 - running injected task 0x%.08x\n", ctx.id, taskNode)
+      taskNode.runTask()
+      continue # back to step 1
+
     if tp.numThreads == 1 or foreignThreadsParked:
       break
 
-    # 2. Help other threads
-    debug: log("Worker %2d: syncAll 2 - becoming a thief\n", ctx.id)
+    # 4. Help other threads
+    debug: log("Worker %2d: syncAll 4 - becoming a thief\n", ctx.id)
     var taskNode = ctx.trySteal()
 
     if not taskNode.isNil:
-      # 2.1 We stole some task
-      debug: log("Worker %2d: syncAll 2.1 - stole task 0x%.08x (parent 0x%.08x, current 0x%.08x)\n", ctx.id, taskNode, taskNode.parent, ctx.currentTask)
+      # 4.1 We stole some task
+      debug: log("Worker %2d: syncAll 4.1 - stole task 0x%.08x (parent 0x%.08x, current 0x%.08x)\n", ctx.id, taskNode, taskNode.parent, ctx.currentTask)
       taskNode.runTask()
     else:
-      # 2.2 No task to steal
+      # 4.2 No task to steal
       if tp.eventNotifier.getParked() == tp.numThreads - 1:
-        # 2.2.1 all threads besides the current are parked
+        # 4.2.1 all threads besides the current are parked
         debugTermination:
-          log("Worker %2d: syncAll 2.2.1 - termination, all other threads sleeping\n", ctx.id)
+          log("Worker %2d: syncAll 4.2.1 - termination, all other threads sleeping\n", ctx.id)
         foreignThreadsParked = true
       else:
-        # 2.2.2 We don't park as there is no notif for task completion
+        # 4.2.2 We don't park as there is no notif for task completion
         cpuRelax()
 
   debugTermination:
@@ -366,6 +442,7 @@ proc new*(T: type Taskpool, numThreads = countProcessors()): T {.raises: [Catcha
   tp.barrier.init(numThreads.int32)
   tp.eventNotifier.initialize()
   tp.numThreads = numThreads
+  tp.injectionQueue.store(nil, moRelaxed)
   tp.workerDeques = tp_allocArrayAligned(ChaseLevDeque[TaskNode], numThreads, alignment = 64)
   tp.workers = tp_allocArrayAligned(Thread[(Taskpool, WorkerID)], numThreads, alignment = 64)
   tp.workerSignals = tp_allocArrayAligned(Signal, numThreads, alignment = 64)
@@ -404,6 +481,8 @@ proc cleanup(tp: var Taskpool) =
 
   tp.tp_freeAligned()
 
+# XXX prevent external threads enqueue tasks into injectQueue
+#     before calling syncAll
 proc shutdown*(tp: var Taskpool) =
   ## Wait until all tasks are processed and then shutdown the taskpool
   preCondition: workerContext.currentTask.isRootTask()
@@ -432,6 +511,7 @@ proc shutdown*(tp: var Taskpool) =
 
 macro spawn*(tp: Taskpool, fnCall: typed): untyped =
   ## Spawns the input function call asynchronously, potentially on another thread of execution.
+  ## Safe to call from any thread, including threads that are not part of the taskpool.
   ##
   ## If the function calls returns a result, spawn will wrap it in a Flowvar.
   ## You can use `sync` to block the current thread and extract the asynchronous result from the flowvar.
@@ -544,7 +624,7 @@ macro spawn*(tp: Taskpool, fnCall: typed): untyped =
         # to the task, potentially on a different thread
         result.add quote do:
           type `argsTy` = typeof(`argsTup`)
-          let `args` = createShared(`argsTy`)
+          let `args` = tp_alloc(`argsTy`, zero = true)
           `args`[] = `argsTup`
 
         # ... and free it after the task has finished running - because we moved
@@ -552,7 +632,7 @@ macro spawn*(tp: Taskpool, fnCall: typed): untyped =
         # nothing left to process
         body.add quote do:
           wasMoved(`env`[])
-          freeShared(`env`)
+          tp_free(`env`)
         args
       else:
         newNilLit()
@@ -563,8 +643,12 @@ macro spawn*(tp: Taskpool, fnCall: typed): untyped =
     proc `taskFn`(`envp`: pointer) {.nimcall, gcsafe, raises: [].} =
       `body`
 
-    let taskNode = TaskNode.new(workerContext.currentTask, `taskFn`, `args`)
-    schedule(workerContext, taskNode)
+    if workerContext.taskpool != `tp`:
+      let taskNode = TaskNode.new(nil, `taskFn`, `args`)
+      submitTask(`tp`, taskNode)
+    else:
+      let taskNode = TaskNode.new(workerContext.currentTask, `taskFn`, `args`)
+      schedule(workerContext, taskNode)
 
     `fut`
 

--- a/taskpools/taskpools.nim
+++ b/taskpools/taskpools.nim
@@ -42,7 +42,7 @@ import
   std/[atomics, cpuinfo, isolation, macros, random, typetraits],
   ./[
     ast_utils, channels_spsc_single, chase_lev_deques, event_notifiers, flowvars,
-    sparsesets,
+    injection_queues, sparsesets,
   ],
   ./primitives/[barriers, allocs],
   ./instrumentation/[contracts, loggers]
@@ -50,16 +50,6 @@ import
 export
   # flowvars
   Flowvar, isSpawned, isReady, sync, isolation
-
-const TasksBetweenInjectionDrains {.intdefine: "taskpoolsIqDrainTick".} = 61
-  ## Drain the external threads task queue after processing at most this many local tasks,
-  ## so externally submitted tasks are not starved while a worker churns through
-  ## a local deque that internal spawns keep refilling. Prime to avoid resonance
-  ## with regular workload sizes. Override with `-d:taskpoolsIqDrainTick:N`.
-
-static:
-  doAssert TasksBetweenInjectionDrains > 0,
-    "taskpoolsIqDrainTick must be a positive integer"
 
 const sharedHeap = defined(gcArc) or defined(gcOrc) or defined(gcAtomicArc)
 
@@ -72,9 +62,8 @@ type
     parent: TaskNode
     callback*: TaskCallback
     args*: pointer
-    # intrusive link for the injection queue;
-    # ordering is guaranteed by release/acquire on injectionQueue
-    injectionNext: TaskNode
+    # intrusive link for the InjectionQueue Treiber stack
+    injectionNext*: TaskNode
 
   Signal = object
     terminate {.align: 64.}: Atomic[bool]
@@ -114,10 +103,9 @@ type
     workerSignals: ptr UncheckedArray[Signal]
       ## Access signaledTerminate
 
-    injectionQueue {.align: 64.}: Atomic[TaskNode]
-      ## Lock-free MPMC injection queue (Treiber stack).
-      ## Any thread may push; any worker may drain via atomic exchange;
-      ## only one worker wins the exchange per drain call.
+    injectionQueue {.align: 64.}: InjectionQueue[TaskNode]
+      ## Lock-free MPMC queue for tasks submitted by threads that are not
+      ## currently running the scheduler (external threads or foreign pools).
 
 when not sharedHeap:
   proc supportsThreadMove*(T: type): bool {.compileTime.} =
@@ -231,32 +219,16 @@ proc schedule(ctx: WorkerContext, tn: sink TaskNode) {.inline.} =
 proc submitTask(tp: Taskpool, tn: TaskNode) {.inline.} =
   ## Push a task onto the injection queue from any thread.
   ## Workers will drain the queue into their Chase-Lev deques, making tasks stealable.
-  ##
-  ## Uses a Treiber stack (lock-free MPMC push, single-winner drain via exchange).
-  ## The release CAS on injectionQueue makes the plain write to tn.injectionNext
-  ## visible to the draining worker after its acquire exchange.
-  var headOld = tp.injectionQueue.load(moRelaxed)
-  while true:
-    tn.injectionNext = headOld  # plain write; ordered by the release CAS below
-    if tp.injectionQueue.compareExchange(headOld, tn, moRelease, moRelaxed):
-      break
+  tp.injectionQueue.push(tn)
   tp.eventNotifier.notify()
 
 proc drainInjectionQueue(ctx: var WorkerContext) {.inline.} =
   ## Atomically claim the entire injection queue and push all tasks into
   ## the calling worker's Chase-Lev deque, where they become stealable.
-  ## Only one worker wins the exchange; the others get nil and return immediately.
-  if ctx.taskpool.injectionQueue.load(moRelaxed).isNil:
-    return
-  var node = ctx.taskpool.injectionQueue.exchange(nil, moAcquire)
-  if node.isNil:
-    return
+  ## Only one worker wins the exchange; the others drain nothing.
   var count = 0
-  while not node.isNil:
-    let next = node.injectionNext  # plain read; ordered by the acquire exchange above
-    node.injectionNext = nil
+  for node in ctx.taskpool.injectionQueue.drain():
     ctx.taskDeque[].push(node)
-    node = next
     inc count
   # Wake workers so the newly stealable tasks get parallel attention.
   let toWake = min(count, ctx.taskpool.eventNotifier.getParked())
@@ -457,7 +429,7 @@ proc new*(T: type Taskpool, numThreads = countProcessors()): T {.raises: [Catcha
   tp.barrier.init(numThreads.int32)
   tp.eventNotifier.initialize()
   tp.numThreads = numThreads
-  tp.injectionQueue.store(nil, moRelaxed)
+  tp.injectionQueue.init()
   tp.workerDeques = tp_allocArrayAligned(ChaseLevDeque[TaskNode], numThreads, alignment = 64)
   tp.workers = tp_allocArrayAligned(Thread[(Taskpool, WorkerID)], numThreads, alignment = 64)
   tp.workerSignals = tp_allocArrayAligned(Signal, numThreads, alignment = 64)

--- a/taskpools/taskpools.nim
+++ b/taskpools/taskpools.nim
@@ -481,8 +481,6 @@ proc cleanup(tp: var Taskpool) =
 
   tp.tp_freeAligned()
 
-# XXX prevent external threads enqueue tasks into injectQueue
-#     before calling syncAll
 proc shutdown*(tp: var Taskpool) =
   ## Wait until all tasks are processed and then shutdown the taskpool
   preCondition: workerContext.currentTask.isRootTask()

--- a/taskpools/taskpools.nim
+++ b/taskpools/taskpools.nim
@@ -51,6 +51,16 @@ export
   # flowvars
   Flowvar, isSpawned, isReady, sync, isolation
 
+const TasksBetweenInjectionDrains {.intdefine: "taskpoolsIqDrainTick".} = 61
+  ## Drain the external threads task queue after processing at most this many local tasks,
+  ## so externally submitted tasks are not starved while a worker churns through
+  ## a local deque that internal spawns keep refilling. Prime to avoid resonance
+  ## with regular workload sizes. Override with `-d:taskpoolsIqDrainTick:N`.
+
+static:
+  doAssert TasksBetweenInjectionDrains > 0,
+    "taskpoolsIqDrainTick must be a positive integer"
+
 const sharedHeap = defined(gcArc) or defined(gcOrc) or defined(gcAtomicArc)
 
 type
@@ -231,12 +241,6 @@ proc submitTask(tp: Taskpool, tn: TaskNode) {.inline.} =
     if tp.injectionQueue.compareExchange(headOld, tn, moRelease, moRelaxed):
       break
   tp.eventNotifier.notify()
-
-const TasksBetweenInjectionDrains = 61
-  ## Drain the injection queue after processing at most this many local tasks,
-  ## so externally submitted tasks are not starved while a worker churns through
-  ## a local deque that internal spawns keep refilling. Prime to avoid resonance
-  ## with regular workload sizes.
 
 proc drainInjectionQueue(ctx: var WorkerContext) {.inline.} =
   ## Atomically claim the entire injection queue and push all tasks into

--- a/tests/test_all.nim
+++ b/tests/test_all.nim
@@ -11,6 +11,7 @@ import ./[
   test_bpc,
   test_calltypes,
   test_dfs,
+  test_external_queue,
   test_fib,
   test_heat,
   test_nqueens,

--- a/tests/test_external_queue.nim
+++ b/tests/test_external_queue.nim
@@ -30,6 +30,17 @@ proc submitter(ctx: Context) {.thread.} =
   for i in 0 ..< ctx.numTasks:
     ctx.tp.spawn work(ctx.executed)
 
+proc work2(): int =
+  123
+
+proc submitterFv(ctx: Context) {.thread.} =
+  var futs = newSeq[Flowvar[int]]()
+  for i in 0 ..< ctx.numTasks:
+    futs.add ctx.tp.spawn work2()
+  for fut in futs:
+    doAssert sync(fut) == 123
+    discard ctx.executed[].fetchAdd(1, moRelaxed)
+
 suite "External threads task queue":
   setup:
     var tp = Taskpool.new(numThreads())
@@ -70,6 +81,30 @@ suite "External threads task queue":
     var threads = newSeq[Thread[Context]](externalThreads)
     for t in mitems(threads):
       createThread(t, submitter, (tp, tasksPerThread, addr executed))
+    joinThreads(threads)
+    tp.syncAll()
+    check executed.load(moAcquire) == externalThreads * tasksPerThread
+
+  test "flowvar; externalThreads=1; tasksPerThread=10_000":
+    const
+      externalThreads = 1
+      tasksPerThread = 10_000
+    var executed: Atomic[int]
+    var threads = newSeq[Thread[Context]](externalThreads)
+    for t in mitems(threads):
+      createThread(t, submitterFv, (tp, tasksPerThread, addr executed))
+    joinThreads(threads)
+    tp.syncAll()
+    check executed.load(moAcquire) == externalThreads * tasksPerThread
+
+  test "flowvar; externalThreads=100; tasksPerThread=10_000":
+    const
+      externalThreads = 100
+      tasksPerThread = 10_000
+    var executed: Atomic[int]
+    var threads = newSeq[Thread[Context]](externalThreads)
+    for t in mitems(threads):
+      createThread(t, submitterFv, (tp, tasksPerThread, addr executed))
     joinThreads(threads)
     tp.syncAll()
     check executed.load(moAcquire) == externalThreads * tasksPerThread

--- a/tests/test_external_queue.nim
+++ b/tests/test_external_queue.nim
@@ -1,0 +1,75 @@
+# taskpools
+# Copyright (c) 2021-2026 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [], gcsafe.}
+
+import
+  std/atomics,
+  unittest2,
+  ./utils,
+  ../taskpools
+
+# Exercises the injection queue path: tasks spawned from threads that are not
+# part of the taskpool go through submitTask() and are picked up by workers via
+# drainInjectionQueue().
+
+type
+  Context = tuple
+    tp: Taskpool
+    numTasks: int
+    executed: ptr Atomic[int]
+
+proc work(executed: ptr Atomic[int]) =
+  discard executed[].fetchAdd(1, moRelaxed)
+
+proc submitter(ctx: Context) {.thread.} =
+  for i in 0 ..< ctx.numTasks:
+    ctx.tp.spawn work(ctx.executed)
+
+suite "External threads task queue":
+  setup:
+    var tp = Taskpool.new(numThreads())
+
+  teardown:
+    tp.syncAll()
+    tp.shutdown()
+
+  test "externalThreads=1; tasksPerThread=10_000":
+    const
+      externalThreads = 1
+      tasksPerThread = 10_000
+    var executed: Atomic[int]
+    var threads = newSeq[Thread[Context]](externalThreads)
+    for t in mitems(threads):
+      createThread(t, submitter, (tp, tasksPerThread, addr executed))
+    joinThreads(threads)
+    tp.syncAll()
+    check executed.load(moAcquire) == externalThreads * tasksPerThread
+
+  test "externalThreads=100; tasksPerThread=10_000":
+    const
+      externalThreads = 100
+      tasksPerThread = 10_000
+    var executed: Atomic[int]
+    var threads = newSeq[Thread[Context]](externalThreads)
+    for t in mitems(threads):
+      createThread(t, submitter, (tp, tasksPerThread, addr executed))
+    joinThreads(threads)
+    tp.syncAll()
+    check executed.load(moAcquire) == externalThreads * tasksPerThread
+
+  test "externalThreads=1_000; tasksPerThread=1_000":
+    const
+      externalThreads = 1_000
+      tasksPerThread = 1_000
+    var executed: Atomic[int]
+    var threads = newSeq[Thread[Context]](externalThreads)
+    for t in mitems(threads):
+      createThread(t, submitter, (tp, tasksPerThread, addr executed))
+    joinThreads(threads)
+    tp.syncAll()
+    check executed.load(moAcquire) == externalThreads * tasksPerThread


### PR DESCRIPTION
Fixes #6

Adds an `injectQueue` which any thread can use to add tasks. After consuming local tasks, before trying to steal, tasks are drained from `injectQueue` into the local queue and processed; ~LIFO order is maintained.

One flaw of this approach is if the tasks keep spawning tasks faster than they complete and so all workers are permanently busy, the tasks in inject-queue won't run. They only run if at some point one of the workers has no pending tasks. The injection-queue is drained every 61 processed local tasks to avoid this.

On my machine current benchmarks show no difference.

Added 2 benchs. The `taskpool_spc_external` can be used to compare VS the `taskpool_spc` queueing to local queue. The `iqs_latency/taskpool_iqs_latency.nim` shows latency of injected tasks when the local queues are permanently filled.

there is a race cond between a thread adding a task and worker checking the injection queue + parking (if worker see no tasks in the queue, thread adds it, worker parks). But it also seems to exist for local queue + parking. It requires #54 to fix it properly (the sleepy / sleep ticket feature); ~also requires wakeAll to avoid the notification per worker.~ waking one eventually awakes the rest on drain/steal.

Related #9 