### PR TITLE
Fix TSan detected data races

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ The following types and procedures are exposed:
       ## The thread is not idle and will complete pending tasks.
     ```
 
+## Compile flags
+
+- `taskpoolsTsan`: Enable ThreadSanitizer (TSan) support. Example command: `nim c --mm:orc -d:taskpoolsTsan -d:useMalloc -d:release --cc:clang --passc:-fsanitize=thread --passl:-fsanitize=thread --debugger:native -r ./my_app.nim`
+
 ### Non-goals
 
 The following are non-goals:

--- a/taskpools.nimble
+++ b/taskpools.nimble
@@ -31,6 +31,7 @@ proc run(args, path: string) =
   build args & " --mm:orc -r", path
 
   if (NimMajor, NimMinor) >= (2, 2) and defined(linux) and defined(amd64) and "danger" in args:
+    build args & " --mm:arc -d:useMalloc --cc:clang --passc:-fsanitize=address --passl:-fsanitize=address --debugger:native -r", path
     build args & " --mm:orc -d:useMalloc --cc:clang --passc:-fsanitize=address --passl:-fsanitize=address --debugger:native -r", path
     build args & " --mm:orc -d:useMalloc --cc:clang --passc:-fsanitize=thread --passl:-fsanitize=thread --debugger:native -r", path
     build args & " --mm:refc --cc:clang --passc:-fsanitize=thread --passl:-fsanitize=thread --debugger:native -r", path

--- a/taskpools.nimble
+++ b/taskpools.nimble
@@ -33,8 +33,8 @@ proc run(args, path: string) =
   if (NimMajor, NimMinor) >= (2, 2) and defined(linux) and defined(amd64) and "danger" in args:
     build args & " --mm:arc -d:useMalloc --cc:clang --passc:-fsanitize=address --passl:-fsanitize=address --debugger:native -r", path
     build args & " --mm:orc -d:useMalloc --cc:clang --passc:-fsanitize=address --passl:-fsanitize=address --debugger:native -r", path
-    build args & " --mm:orc -d:useMalloc --cc:clang --passc:-fsanitize=thread --passl:-fsanitize=thread --debugger:native -r", path
-    build args & " --mm:refc --cc:clang --passc:-fsanitize=thread --passl:-fsanitize=thread --debugger:native -r", path
+    build args & " --mm:orc -d:taskpoolsTsan -d:useMalloc --cc:clang --passc:-fsanitize=thread --passl:-fsanitize=thread --debugger:native -r", path
+    build args & " --mm:refc -d:taskpoolsTsan --cc:clang --passc:-fsanitize=thread --passl:-fsanitize=thread --debugger:native -r", path
 
 proc runTests(args: string) =
   # Internal data structures

--- a/taskpools.nimble
+++ b/taskpools.nimble
@@ -9,6 +9,8 @@ skipDirs      = @["tests"]
 
 requires "nim >= 2.0.14"
 
+import strutils
+
 let nimc = getEnv("NIMC", "nim") # Which nim compiler to use
 let lang = getEnv("NIMLANG", "c") # Which backend (c/cpp/js)
 let flags = getEnv("NIMFLAGS", "") # Extra flags for the compiler
@@ -26,29 +28,37 @@ proc build(args, path: string) =
 
 proc run(args, path: string) =
   build args & " --mm:refc -r", path
-  if (NimMajor, NimMinor) > (1, 6):
-    build args & " --mm:orc -r", path
+  build args & " --mm:orc -r", path
 
-task test, "Run Taskpools tests":
+  if (NimMajor, NimMinor) >= (2, 2) and defined(linux) and defined(amd64) and "danger" in args:
+    build args & " --mm:orc -d:useMalloc --cc:clang --passc:-fsanitize=address --passl:-fsanitize=address --debugger:native -r", path
+    build args & " --mm:orc -d:useMalloc --cc:clang --passc:-fsanitize=thread --passl:-fsanitize=thread --debugger:native -r", path
+    build args & " --mm:refc --cc:clang --passc:-fsanitize=thread --passl:-fsanitize=thread --debugger:native -r", path
+
+proc runTests(args: string) =
   # Internal data structures
-  run "", "taskpools/channels_spsc_single.nim"
-  run "", "taskpools/sparsesets.nim"
+  run args, "taskpools/channels_spsc_single.nim"
+  run args, "taskpools/sparsesets.nim"
 
   # Examples
-  run "", "examples/e01_simple_tasks.nim"
-  run "", "examples/e02_parallel_pi.nim"
+  run args, "examples/e01_simple_tasks.nim"
+  run args, "examples/e02_parallel_pi.nim"
 
   # Benchmarks
-  run "", "benchmarks/dfs/taskpool_dfs.nim"
-  run "", "benchmarks/heat/taskpool_heat.nim"
-  run "", "benchmarks/nqueens/taskpool_nqueens.nim"
+  run args, "benchmarks/dfs/taskpool_dfs.nim"
+  run args, "benchmarks/heat/taskpool_heat.nim"
+  run args, "benchmarks/nqueens/taskpool_nqueens.nim"
 
   # Tests
-  run "", "tests/test_calltypes.nim"
+  run args, "tests/test_calltypes.nim"
 
   when not defined(windows):
-    run "", "benchmarks/single_task_producer/taskpool_spc.nim"
-    run "", "benchmarks/bouncing_producer_consumer/taskpool_bpc.nim"
+    run args, "benchmarks/single_task_producer/taskpool_spc.nim"
+    run args, "benchmarks/bouncing_producer_consumer/taskpool_bpc.nim"
 
   # TODO - generics in macro issue
-  # run "", "benchmarks/matmul_cache_oblivious/taskpool_matmul_co.nim"
+  # run args, "benchmarks/matmul_cache_oblivious/taskpool_matmul_co.nim"
+
+task test, "Run Taskpools tests":
+  for mode in ["", "-d:release", "-d:danger"]:
+    runTests(mode)

--- a/taskpools/chase_lev_deques.nim
+++ b/taskpools/chase_lev_deques.nim
@@ -114,8 +114,8 @@ proc grow[T](deque: var ChaseLevDeque[T], buf: var ptr Buf[T], top, bottom: int)
   buf.prev = deque.garbage
   deque.garbage = buf
   # publish globally
-  deque.buf.store(tmp, moRelaxed)
-  # publish locally
+  # moRelease for buf.load(moConsume) in steal
+  deque.buf.store(tmp, moRelease)
   swap(buf, tmp)
 
 # Public API
@@ -149,8 +149,7 @@ proc push*[T](deque: var ChaseLevDeque[T], item: T) =
     deque.grow(a, t, b)
 
   a[][b] = item
-  fence(moRelease)
-  deque.bottom.store(b+1, moRelaxed)
+  deque.bottom.store(b+1, moRelease)
 
 proc pop*[T](deque: var ChaseLevDeque[T]): T =
   ## Deque an item at the bottom

--- a/taskpools/chase_lev_deques.nim
+++ b/taskpools/chase_lev_deques.nim
@@ -151,6 +151,9 @@ proc push*[T](deque: var ChaseLevDeque[T], item: T) =
 
   a[][b] = item
   when defined(taskpoolsTsan):
+    # TSan does not support atomic_thread_fence, see:
+    # https://github.com/llvm/llvm-project/issues/52942
+    # https://github.com/google/sanitizers/issues/1352
     deque.bottom.store(b+1, moRelease)
   else:
     fence(moRelease)

--- a/taskpools/chase_lev_deques.nim
+++ b/taskpools/chase_lev_deques.nim
@@ -150,7 +150,11 @@ proc push*[T](deque: var ChaseLevDeque[T], item: T) =
     deque.grow(a, t, b)
 
   a[][b] = item
-  deque.bottom.store(b+1, moRelease)
+  when defined(taskpoolsTsan):
+    deque.bottom.store(b+1, moRelease)
+  else:
+    fence(moRelease)
+    deque.bottom.store(b+1, moRelaxed)
 
 proc pop*[T](deque: var ChaseLevDeque[T]): T =
   ## Deque an item at the bottom

--- a/taskpools/chase_lev_deques.nim
+++ b/taskpools/chase_lev_deques.nim
@@ -116,6 +116,7 @@ proc grow[T](deque: var ChaseLevDeque[T], buf: var ptr Buf[T], top, bottom: int)
   # publish globally
   # moRelease for buf.load(moConsume) in steal
   deque.buf.store(tmp, moRelease)
+  # publish locally
   swap(buf, tmp)
 
 # Public API


### PR DESCRIPTION
Changes:

- Fix TSan detected data races.
- Run tests with TSan and ASan.
- Run tests in debug, release, danger mode.

Issues found in `nim c -d:danger --mm:orc -d:useMalloc --cc:clang --passc:-fsanitize=thread --passl:-fsanitize=thread --debugger:native -r ./benchmarks/single_task_producer/taskpool_spc.nim`.

CC @mratsim