### PR TITLE
`sync`: allow awaiting threads to sleep

### DIFF
--- a/benchmarks/dfs/taskpool_dfs.nim
+++ b/benchmarks/dfs/taskpool_dfs.nim
@@ -65,7 +65,7 @@ proc main() =
   when not defined(windows):
     let start = wtime_usec()
 
-  tp = Taskpool.new()
+  tp = Taskpool.new(numThreads = nthreads)
   answer = test(depth, breadth)
   tp.shutdown()
 

--- a/benchmarks/fibonacci/taskpool_fib.nim
+++ b/benchmarks/fibonacci/taskpool_fib.nim
@@ -40,7 +40,7 @@ proc main() =
   else:
     nthreads = countProcessors()
 
-  tp = Taskpool.new()
+  tp = Taskpool.new(numThreads = nthreads)
 
   # measure overhead during tasking
   when not defined(windows):

--- a/taskpools.nimble
+++ b/taskpools.nimble
@@ -76,4 +76,3 @@ task test_bench, "Run benchs":
 
   # Avoid TSan; it's too slow
   run "-d:release", "benchmarks/fibonacci/taskpool_fib.nim"
-  run "-d:release", "tests/stress/test_shutdown.nim"

--- a/taskpools.nimble
+++ b/taskpools.nimble
@@ -76,3 +76,4 @@ task test_bench, "Run benchs":
 
   # Avoid TSan; it's too slow
   run "-d:release", "benchmarks/fibonacci/taskpool_fib.nim"
+  run "-d:release", "tests/stress/test_shutdown.nim"

--- a/taskpools/flowvars.nim
+++ b/taskpools/flowvars.nim
@@ -10,7 +10,7 @@
 
 import
   std/atomics,
-  ./primitives/allocs
+  ./primitives/[allocs, futexes]
 
 # Tasks have an efficient design so that a single heap allocation
 # is required per `spawn`.
@@ -25,6 +25,22 @@ import
 # Flowvars are also called future interchangeably.
 
 type
+  TaskState = object
+    ## This state allows synchronization between:
+    ## - a waiter that may sleep if no work and task is incomplete
+    ## - a runner, the task creator or a thief, that completes the task
+    ## - a waiter that frees the task memory
+    ##
+    ## Supports up to 2¹⁵ = 32768 threads
+    completed: Futex
+    synchro: Atomic[uint32]
+    # type synchro = object
+    #   canBeFreed {.bitsize:  1.}: uint32 - Transfer ownership from runner to waiter
+    #   pad        {.bitsize:  1.}: uint32
+    #   waiterID   {.bitsize: 15.}: uint32 - ID of the waiter blocked on the task completion.
+    #                                        ID is always 0 for external threads.
+    #   unused     {.bitsize: 15.}: uint32 - Leapfrogging stores the thief ID here.
+
   TaskCallback* = proc(env: pointer) {.nimcall, gcsafe, raises: [].}
 
   TaskNode* = ptr object
@@ -33,7 +49,7 @@ type
     # Intrusive link for the InjectionQueue Treiber stack
     injectionNext*: TaskNode
     callback*: TaskCallback
-    completed: Atomic[bool] # Readiness flag for an awaiting Flowvar
+    state: TaskState
     hasFuture*: bool # Ownership: if true the awaiter frees the node, otherwise the runner frees it once run.
     env*{.align: sizeof(int).}: UncheckedArray[byte]
 
@@ -44,6 +60,83 @@ type
     # and stored cheaply in collections.
     tn: TaskNode
 
+# Task state
+# ------------------------------------------------------------------------------
+
+# Tasks have the following lifecycle:
+# - a task creator schedules a task on its queue
+# - a task runner, the creator or a thief, runs the task
+# - once the task is finished:
+#   - if the task has no future, the runner frees the task
+#   - if the task has a future,
+#     - the runner can immediately pick up new work
+#     - the awaiting thread reads the result and frees the task
+#     - the awaiting thread may have run out of work and parked on the task,
+#       in which case it needs to be woken up
+#
+# There is a delicate dance as we need to prevent 2 issues:
+#
+# 1. A deadlock:       if the waiter is never woken up after the runner completes the task
+# 2. A use-after-free: if the runner touches the task after the waiter freed it
+#
+# To solve 1, the runner sets the `completed` flag, then checks again whether a
+#             waiter registered in the meantime, and wakes it if so.
+# To solve 2, we cannot require the runner to stop touching the task once it is
+#             completed, as solving 1 forces it to read `synchro` afterwards.
+#             Instead the runner hands the task over with `canBeFreed`, which the
+#             waiter spins on before deallocating.
+
+const # `synchro` bitfield
+  kCanBeFreedShift = 31
+  kCanBeFreed      = 1'u32 shl kCanBeFreedShift
+
+  kWaiterShift     = 15
+  kWaiterMask      = ((1'u32 shl kWaiterShift) - 1) shl kWaiterShift
+  SentinelWaiter   = kWaiterMask
+    ## No thread is parked on the task
+  maxWaiterID      = int32(SentinelWaiter shr kWaiterShift) - 1
+    ## Highest ID a waiter can have, one below the sentinel
+
+proc initSynchroState(tn: TaskNode) {.inline.} =
+  tn.state.completed.initialize()
+  tn.state.synchro.store(SentinelWaiter, moRelaxed)
+
+proc teardownSynchroState(tn: TaskNode) {.inline.} =
+  tn.state.completed.teardown()
+
+# Flowvar synchronization
+# ------------------------------------------------------------------------------
+
+proc isGcReady*(tn: TaskNode): bool {.inline.} =
+  ## Check whether the runner is done accessing a task it handed to the waiter.
+  (tn.state.synchro.load(moAcquire) and kCanBeFreed) != 0
+
+proc setGcReady*(tn: TaskNode) {.inline.} =
+  ## The runner transfers full ownership of the task to the waiter.
+  ## The task must not be accessed by the runner afterwards.
+  discard tn.state.synchro.fetchAdd(kCanBeFreed, moRelease)
+
+proc isCompleted*(tn: TaskNode): bool {.inline.} =
+  ## Check task completion.
+  tn.state.completed.load(moAcquire) != 0
+
+proc setCompleted*(tn: TaskNode) {.inline.} =
+  ## Mark a task as complete and wake the awaiting thread if it parked.
+  tn.state.completed.store(1, moRelease)
+  fence(moSequentiallyConsistent)
+  let waiter = tn.state.synchro.load(moRelaxed)
+  if (waiter and kWaiterMask) != SentinelWaiter:
+    tn.state.completed.wake()
+
+proc sleepUntilComplete*(tn: TaskNode, waiterID: int32) {.inline.} =
+  ## Park the current thread until the task is completed by the thread running it.
+  assert 0 <= waiterID and waiterID <= maxWaiterID
+  let waiter = (cast[uint32](waiterID) shl kWaiterShift) - SentinelWaiter
+  discard tn.state.synchro.fetchAdd(waiter, moRelaxed)
+  fence(moAcquire)
+  while tn.state.completed.load(moRelaxed) == 0:
+    tn.state.completed.wait(0)
+
 # TaskNode
 # ------------------------------------------------------------------------------
 
@@ -52,13 +145,16 @@ proc new*(T: type TaskNode, parent: TaskNode, callback: TaskCallback, envSize: i
   tn.parent = parent
   tn.injectionNext = nil
   tn.callback = callback
-  tn.completed.store(false, moRelaxed)
+  tn.initSynchroState()
   tn.hasFuture = false
   tn
 
-proc setCompleted*(tn: TaskNode) {.inline.} =
-  ## Mark a task as complete.
-  tn.completed.store(true, moRelease)
+proc free*(tn: var TaskNode) {.inline.} =
+  ## Release a task node. The caller must own it, see "Task state".
+  if not tn.isNil:
+    tn.teardownSynchroState()
+    tp_free(tn)
+    tn = nil
 
 # Flowvars
 # ------------------------------------------------------------------------------
@@ -76,9 +172,11 @@ proc newFlowVar*(T: typedesc, tn: TaskNode): Flowvar[T] {.inline.} =
   result.tn = tn
   tn.hasFuture = true
 
-proc cleanup(fv: var Flowvar) {.inline.} =
+proc cleanup*(fv: var Flowvar) {.inline.} =
   if not fv.tn.isNil:
-    tp_free(fv.tn)
+    while not fv.tn.isGcReady():
+      cpuRelax()
+    fv.tn.free()
     fv.tn = nil
 
 func isSpawned*(fv: Flowvar): bool {.inline.} =
@@ -93,22 +191,20 @@ func isReady*[T](fv: Flowvar[T]): bool {.inline.} =
   ## In that case `sync` will not block.
   ## Otherwise the current will block to help on all the pending tasks
   ## until the Flowvar is ready.
-  fv.tn.completed.load(moAcquire)
+  fv.tn.isCompleted()
 
 proc tryComplete*[T](fv: Flowvar[T], parentResult: var T): bool {.inline.} =
   ## If the task is complete, move its result into `parentResult` and return true.
-  if fv.tn.completed.load(moAcquire):
+  if fv.tn.isCompleted():
     parentResult = move(cast[ptr T](fv.tn.env.addr)[])
     true
   else:
     false
 
-proc sync*[T](fv: sink Flowvar[T]): T {.inline, gcsafe.} =
-  ## Blocks the current thread until the flowvar is available and returned.
-  ## Worker threads help execute pending tasks while waiting.
-  ## Non-worker (external) threads busy-wait instead.
-  mixin forceFuture
-  forceFuture(fv, result)
-  cleanup(fv)
+proc sleepUntilReady*(fv: Flowvar, waiterID: int32) {.inline.} =
+  ## Park the current thread until the task backing the flowvar completes.
+  ## Only park when there is no other work to do: the thread is only woken
+  ## by the completion of that very task.
+  fv.tn.sleepUntilComplete(waiterID)
 
 {.pop.} # raises: []

--- a/taskpools/injection_queues.nim
+++ b/taskpools/injection_queues.nim
@@ -49,6 +49,11 @@ proc init*[T](q: var InjectionQueue[T]) {.inline.} =
   ## Reset the queue to empty. Must be called before any push/drain.
   q.head.store(default(T), moRelaxed)
 
+proc isEmpty*[T](q: var InjectionQueue[T]): bool {.inline.} =
+  ## Whether the queue holds no node. Only meaningful once no thread can still
+  ## push, ie at teardown: otherwise the answer is stale as soon as it is returned.
+  q.head.load(moAcquire).isNil
+
 proc push*[T](q: var InjectionQueue[T], node: T, wasEmpty: var bool) {.inline.} =
   ## Push a node onto the queue from any thread (lock-free MPMC).
   ## `wasEmpty` is set to `true` if the queue was empty before the push.

--- a/taskpools/taskpools.nim
+++ b/taskpools/taskpools.nim
@@ -38,7 +38,6 @@
 {.push raises: [], gcsafe.} # Ensure no exceptions can happen
 
 import
-  system/ansi_c,
   std/[atomics, cpuinfo, isolation, macros, random, typetraits],
   ./[
     ast_utils, backoff, chase_lev_deques, flowvars,
@@ -49,7 +48,7 @@ import
 
 export
   # flowvars
-  Flowvar, isSpawned, isReady, sync, isolation
+  Flowvar, isSpawned, isReady, isolation
 
 const sharedHeap = defined(gcArc) or defined(gcOrc) or defined(gcAtomicArc)
 
@@ -187,7 +186,7 @@ proc workerEntryFn(params: tuple[taskpool: Taskpool, id: WorkerID]) =
 # Tasks
 # ---------------------------------------------
 
-proc runTask(ctx: var WorkerContext, tn: TaskNode) {.inline.} =
+proc runTask(ctx: var WorkerContext, tn: var TaskNode) {.inline.} =
   ## Run a task and consume the task node.
   ##
   ## The task environment is intrusive to the node, so the callback receives a
@@ -199,9 +198,12 @@ proc runTask(ctx: var WorkerContext, tn: TaskNode) {.inline.} =
   tn.callback(tn.env.addr)
   ctx.currentTask = suspendedTask
   if tn.hasFuture:
+    # Sync with an awaiting thread that may have parked on the task,
+    # then transfer ownership of the node to it.
     tn.setCompleted()
+    tn.setGcReady()
   else:
-    tp_free(tn)
+    tn.free()
 
 proc schedule(ctx: WorkerContext, tn: sink TaskNode, forceWake = false) {.inline.} =
   ## Schedule a task in the taskpool.
@@ -227,12 +229,14 @@ proc submitTask(tp: Taskpool, tn: TaskNode) {.inline.} =
     # the next worker will wake one after steal, and so on.
     tp.globalBackoff.wake()
 
-proc drainInjectionQueue(ctx: var WorkerContext) {.inline.} =
+proc drainInjectionQueue(ctx: var WorkerContext): bool {.inline, discardable.} =
   ## Atomically claim the entire injection queue and push all tasks into
   ## the calling worker's Chase-Lev deque, where they become stealable.
   ## Only one worker wins the exchange; the others drain nothing.
+  result = false
   for node in ctx.taskpool.injectionQueue.drain():
     ctx.taskDeque[].push(node)
+    result = true
 
 # Scheduler
 # ---------------------------------------------
@@ -266,7 +270,8 @@ proc eventLoop(ctx: var WorkerContext) =
       inc processed
       if processed >= tasksBetweenInjectionDrains:
         processed = 0
-        ctx.drainInjectionQueue()
+        if ctx.drainInjectionQueue():
+          ctx.taskpool.globalBackoff.wake()
 
     let ticket = ctx.taskpool.globalBackoff.sleepy()
 
@@ -310,7 +315,7 @@ proc RootTask(env: pointer) =
 template isRootTask(task: TaskNode): bool {.used.} =
   task.callback == RootTask
 
-proc forceFuture*[T](fv: Flowvar[T], parentResult: var T) =
+proc completeFuture[T](fv: Flowvar[T], parentResult: var T) =
   ## Eagerly complete an awaited Flowvar
 
   template ctx: untyped = workerContext
@@ -322,10 +327,10 @@ proc forceFuture*[T](fv: Flowvar[T], parentResult: var T) =
     return
 
   # External thread: no Chase-Lev deque and no steal peers available.
-  # Busy-wait while pool workers make progress on the task.
+  # There is nothing useful to do, so sleep until a worker completes the task.
   if ctx.taskpool.isNil:
     while not isFutReady():
-      cpuRelax()
+      fv.sleepUntilReady(waiterID = 0)
     return
 
   ## 1. Process all the children of the current tasks.
@@ -348,21 +353,44 @@ proc forceFuture*[T](fv: Flowvar[T], parentResult: var T) =
   ##    in hope it advances our awaited task. This prioritizes latency over throughput.
   debug: log("Worker %2d: sync 2 - future not ready, becoming a thief (currentTask 0x%.08x)\n", ctx.id, ctx.currentTask)
   while not isFutReady():
-    var taskNode = ctx.trySteal()
-
-    if not taskNode.isNil:
+    if (var taskNode = ctx.trySteal(); not taskNode.isNil):
       # Theft successful, there might be more work for idle threads, wake one
       ctx.taskpool.globalBackoff.wake()
       # We stole some task, we hope we advance our awaited task
       debug: log("Worker %2d: sync 2.1 - stole task 0x%.08x (parent 0x%.08x, current 0x%.08x)\n", ctx.id, taskNode, taskNode.parent, ctx.currentTask)
       ctx.runTask(taskNode)
-    # elif (taskNode = ctx.taskDeque[].pop(); not taskNode.isNil):
-    #   # We advance our own queue, this increases throughput but may impact latency on the awaited task
-    #   debug: log("Worker %2d: sync 2.2 - couldn't steal, running own task\n", ctx.id)
-    #   ctx.runTask(taskNode)
+    elif (var taskNode = ctx.taskDeque[].pop(); not taskNode.isNil):
+      # We advance our own queue, this increases throughput but may impact latency on the awaited task.
+      # It is also what makes parking below deadlock-free: a parked thread always
+      # has an empty deque, so the tasks left in it, possibly the awaited one,
+      # cannot be stranded behind a sleeping owner.
+      debug: log("Worker %2d: sync 2.2 - couldn't steal, running own task 0x%.08x (parent 0x%.08x, current 0x%.08x)\n", ctx.id, taskNode, taskNode.parent, ctx.currentTask)
+      ctx.runTask(taskNode)
+    #elif ctx.drainInjectionQueue():
+    #  # Drain injection queue, this increases throughput but may impact latency on the awaited task.
+    #  # These tasks themselves cannot possibly help advance the awaited future,
+    #  # but it could help the worker that would consume the queue if we don't.
+    #  debug: log("Worker %2d: sync 2.3 - drained the injection queue instead of parking\n", ctx.id)
+    #  ctx.taskpool.globalBackoff.wake()
     else:
-      # We don't park as there is no notif for task completion
-      cpuRelax()
+      # Nothing to do, we park until the thread running our awaited task
+      # completes it and wakes us up. We don't park on the global backoff as
+      # it cannot wake a specific thread, so if more work is created in the
+      # meantime we will miss it; that work is for a thread that can run it.
+      debug: log("Worker %2d: sync 2.3.a - empty runtime, sleeping until the awaited task completes\n", ctx.id)
+      fv.sleepUntilReady(ctx.id)
+      debug: log("Worker %2d: sync 2.3.b - awaited task completed, waking\n", ctx.id)
+
+proc sync*[T](fv: sink Flowvar[T]): T {.inline, gcsafe.} =
+  ## Blocks the current thread until the flowvar is available and returned.
+  ## Worker threads help execute pending tasks while waiting, and park on the
+  ## awaited task once they run out. Non-worker (external) threads have no task
+  ## to run, so they park immediately.
+  completeFuture(fv, result)
+  cleanup(fv)
+
+proc forceFuture*[T](fv: sink Flowvar[T], parentResult: var T) {.deprecated: "use sync".} =
+  parentResult = sync(fv)
 
 proc syncAll*(tp: Taskpool) =
   ## Blocks until all pending tasks are completed.
@@ -461,6 +489,8 @@ proc cleanup(tp: var Taskpool) =
   for i in 1 ..< tp.numThreads:
     joinThread(tp.workers[i])
 
+  postCondition: tp.injectionQueue.isEmpty()
+
   tp.workerSignals.tp_freeAligned()
   tp.workers.tp_freeAligned()
   tp.workerDeques.tp_freeAligned()
@@ -487,7 +517,7 @@ proc shutdown*(tp: var Taskpool) =
   tp.cleanup()
 
   # Dealloc dummy task
-  workerContext.currentTask.c_free()
+  workerContext.currentTask.free()
 
 # Task parallelism
 # ---------------------------------------------

--- a/tests/test_all.nim
+++ b/tests/test_all.nim
@@ -19,5 +19,6 @@ import ./[
   test_heat,
   test_nqueens,
   test_single_thread,
-  test_spc
+  test_spc,
+  test_task_backoff
 ]

--- a/tests/test_task_backoff.nim
+++ b/tests/test_task_backoff.nim
@@ -338,7 +338,7 @@ suite "Per-task backoff, section-1 parent mismatch":
     tp.syncAll()
     tp.shutdown()
 
-  test "a non-descendant met in sync is rescheduled, not dropped":
+  test "a non-descendant task in sync is rescheduled":
     # The grandchild is on our deque with a parent that is not our current task,
     # so section 1 hands it back to the pool instead of running it. What must
     # hold is that it is still *somewhere*: a section 1 that broke out without

--- a/tests/test_task_backoff.nim
+++ b/tests/test_task_backoff.nim
@@ -338,15 +338,19 @@ suite "Per-task backoff, section-1 parent mismatch":
     tp.syncAll()
     tp.shutdown()
 
-  test "sync in reverse spawn order meets a grandchild on the deque":
-    # Pathological case that hit the parent-mismatch branch in sync.
+  test "a non-descendant met in sync is rescheduled, not dropped":
+    # The grandchild is on our deque with a parent that is not our current task,
+    # so section 1 hands it back to the pool instead of running it. What must
+    # hold is that it is still *somewhere*: a section 1 that broke out without
+    # rescheduling would leak the node, and no drain would ever find it again.
     let a = tp.spawn gated()
-    while not running.load(moAcquire): # `a` is now off the root's deque
+    while not running.load(moAcquire):
       cpuRelax()
-    let b = tp.spawn reverseInner(0)   # not stealable: worker 1 is on the gate
-    check sync(b) == 2                  # runs `b` inline, leaving the grandchild
+    let b = tp.spawn reverseInner(0)
+    check sync(b) == 2
     var opener: Thread[int]
     createThread(opener, openGate, 100)
-    check sync(a) == 42                 # section-1 mismatch, then parks on `a`
+    check sync(a) == 42
     joinThread(opener)
-    check executed.load(moAcquire) == 1 # the grandchild ran exactly once
+    tp.syncAll()
+    check executed.load(moAcquire) == 1

--- a/tests/test_task_backoff.nim
+++ b/tests/test_task_backoff.nim
@@ -177,6 +177,25 @@ proc handoffAwaiter(rounds: int) {.thread.} =
     doAssert sync(fv) == 1
     handoffFilled.store(false, moRelease)
 
+# Reverse-order await
+# ---------------------------------------------------------------------------
+
+proc reverseInner(spins: int): int =
+  ## Awaited first. Spawns a fire-and-forget grandchild, then returns without
+  ## awaiting it, leaving it queued with *this* task as its parent.
+  tp.spawn bump()
+  for _ in 0 ..< spins:
+    cpuRelax()
+  2
+
+proc reverseOuter(spins: int): int =
+  ## Spawns two children and awaits them in the opposite order of their spawn.
+  let a = tp.spawn counted(spins)
+  let b = tp.spawn reverseInner(spins)
+  let rb = sync(b)
+  let ra = sync(a)
+  ra + rb # counted -> 1, reverseInner -> 2
+
 suite "Per-task backoff stress":
   setup:
     tp = Taskpool.new(numThreads())
@@ -234,6 +253,15 @@ suite "Per-task backoff stress":
   test "dependency chain; depth=200 x 500 rounds":
     for _ in 0 ..< 500:
       check sync(tp.spawn chain(200)) == 200
+
+  test "reverse-order await meets a grandchild; 128 runtimes x 16 rounds":
+    # Pathological case that hit the parent-mismatch branch in sync.
+    const rounds = 16
+    for spins in 0 ..< 128:
+      for _ in 0 ..< rounds:
+        check sync(tp.spawn reverseOuter(spins)) == 3
+    tp.syncAll()
+    check executed.load(moAcquire) == 128 * rounds
 
   test "fork-join tree; depth=12 x 50 rounds":
     for _ in 0 ..< 50:
@@ -294,3 +322,31 @@ suite "Per-task backoff stress, oversubscribed":
       createThread(t, extAwaiter, (tp, rounds))
     joinThreads(threads)
     check executed.load(moAcquire) == externalThreads * rounds
+
+suite "Per-task backoff, section-1 parent mismatch":
+  # Pins the parent-mismatch branch down deterministically, the way the first
+  # suite pins parking down: a 2-worker pool where the only non-root worker is
+  # held on the gate, so nothing the root spawns afterwards can be stolen and the
+  # scheduling is forced.
+  setup:
+    tp = Taskpool.new(2)
+    gate.store(false, moRelease)
+    running.store(false, moRelease)
+    executed.store(0, moRelease)
+
+  teardown:
+    tp.syncAll()
+    tp.shutdown()
+
+  test "sync in reverse spawn order meets a grandchild on the deque":
+    # Pathological case that hit the parent-mismatch branch in sync.
+    let a = tp.spawn gated()
+    while not running.load(moAcquire): # `a` is now off the root's deque
+      cpuRelax()
+    let b = tp.spawn reverseInner(0)   # not stealable: worker 1 is on the gate
+    check sync(b) == 2                  # runs `b` inline, leaving the grandchild
+    var opener: Thread[int]
+    createThread(opener, openGate, 100)
+    check sync(a) == 42                 # section-1 mismatch, then parks on `a`
+    joinThread(opener)
+    check executed.load(moAcquire) == 1 # the grandchild ran exactly once

--- a/tests/test_task_backoff.nim
+++ b/tests/test_task_backoff.nim
@@ -1,0 +1,296 @@
+# taskpools
+# Copyright (c) 2021-2026 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [], gcsafe.}
+
+import
+  std/[atomics, os],
+  unittest2,
+  ./utils,
+  ../taskpools
+
+# Per-task backoff: a thread awaiting a Flowvar with no work left to do parks on
+# the awaited task itself and is woken by the thread that completes it.
+#
+# These tests make the awaiting thread park deterministically: the awaited task
+# is picked up by another thread and cannot complete until a third party opens a
+# gate, by which time the awaiting thread has run out of work. A lost wakeup
+# does not fail these tests, it hangs them - it is a liveness bug, invisible to
+# ThreadSanitizer.
+
+var
+  tp: Taskpool
+  gate: Atomic[bool]
+  running: Atomic[bool]
+
+proc gated(): int =
+  ## Occupies a worker until the gate opens.
+  running.store(true, moRelease)
+  while not gate.load(moAcquire):
+    cpuRelax()
+  42
+
+proc openGate(delayMs: int) {.thread.} =
+  sleep(delayMs)
+  gate.store(true, moRelease)
+
+proc awaitGated(tp: Taskpool) {.thread.} =
+  ## Spawns and awaits from a thread that is not managed by the taskpool.
+  let fv = tp.spawn gated()
+  doAssert sync(fv) == 42
+
+suite "Per-task backoff":
+  setup:
+    tp = Taskpool.new(numThreads())
+    gate.store(false, moRelease)
+    running.store(false, moRelease)
+
+  teardown:
+    tp.syncAll()
+    tp.shutdown()
+
+  test "a worker parks until the awaited task completes":
+    let fv = tp.spawn gated()
+    # Wait until another worker picked up the task: the root thread is then out
+    # of work and parks in `sync` instead of running the task itself.
+    while not running.load(moAcquire):
+      cpuRelax()
+    var opener: Thread[int]
+    createThread(opener, openGate, 100)
+    check sync(fv) == 42
+    joinThread(opener)
+
+  test "an external thread parks until the awaited task completes":
+    var awaiter: Thread[Taskpool]
+    createThread(awaiter, awaitGated, tp)
+    while not running.load(moAcquire):
+      cpuRelax()
+    sleep(100) # Let the awaiting thread reach the park
+    gate.store(true, moRelease)
+    joinThread(awaiter)
+
+  test "park and completion race, 1000 rounds":
+    # No delay here: the gate opens while the awaiting thread is on its way to
+    # park. This races publishing "a waiter is sleeping" against the completion
+    # of the task, the case a missing barrier would turn into a lost wakeup.
+    for _ in 0 ..< 1000:
+      gate.store(false, moRelease)
+      running.store(false, moRelease)
+      let fv = tp.spawn gated()
+      while not running.load(moAcquire):
+        cpuRelax()
+      gate.store(true, moRelease)
+      check sync(fv) == 42
+
+# Stress
+# ---------------------------------------------------------------------------
+#
+# The tests above pin the mechanism down with a gate, so the awaiting thread is
+# guaranteed to park. The ones below drive the same paths under contention,
+# where parking is incidental: whether a given await parks depends on whether a
+# thief got to the task first. They cover the two failure modes of the handover
+# in `flowvars.nim`, both of which manifest as a hang rather than a wrong value:
+#
+# - a lost wakeup: the runner completes the task without seeing the waiter that
+#   registered concurrently, and nobody ever wakes it;
+# - a lost ownership transfer: the waiter registers *after* the runner already
+#   released the node, and its `fetchAdd` clobbers `canBeFreed`, leaving
+#   `cleanup` spinning on a flag that will never be set again.
+#
+# Both need the waiter's registration and the task's completion to land within
+# a few instructions of each other, so the tests sweep the task's runtime
+# rather than fixing it.
+
+var executed: Atomic[int]
+
+proc counted(spins: int): int =
+  ## A task with a tunable runtime. Sweeping `spins` walks the completion of the
+  ## awaited task across the awaiting thread's whole path to the park.
+  for _ in 0 ..< spins:
+    cpuRelax()
+  1
+
+proc bump() =
+  ## Result-less task: the runner owns and frees the node, no handover.
+  discard executed.fetchAdd(1, moRelaxed)
+
+proc chain(depth: int): int =
+  ## Each level spawns exactly one child then awaits it. A level that still has
+  ## its child runs it inline; a level whose child was stolen has an empty deque
+  ## and nothing to steal, so it parks on it. Both happen along the chain.
+  ##
+  ## Keep the depth well under 500: a level that runs its child inline nests
+  ## four frames deep, and `nimCallDepthLimit` caps that at 2000 in any build
+  ## with stack traces (which is every build the nimble test task produces).
+  if depth == 0:
+    return 0
+  let fv = tp.spawn chain(depth - 1)
+  sync(fv) + 1
+
+proc tree(depth: int): int =
+  ## Fork-join. Both children are spawned before either is awaited, so the
+  ## awaiting thread reaches the park only after draining its own deque -
+  ## the invariant that keeps a parked thread from stranding tasks behind it.
+  if depth == 0:
+    return 1
+  let
+    left = tp.spawn tree(depth - 1)
+    right = tp.spawn tree(depth - 1)
+  sync(left) + sync(right)
+
+type
+  StressCtx = tuple
+    tp: Taskpool
+    rounds: int
+
+proc extAwaiter(ctx: StressCtx) {.thread.} =
+  ## An external thread has no deque and no peer to steal from, so every await
+  ## goes straight to the park: each round is a full park/wake cycle.
+  for i in 0 ..< ctx.rounds:
+    let fv = ctx.tp.spawn counted(i mod 64)
+    doAssert sync(fv) == 1
+    discard executed.fetchAdd(1, moRelaxed)
+
+proc extSubmitter(ctx: StressCtx) {.thread.} =
+  ## Fire-and-forget injections landing while workers are parked on futures.
+  ## A parked worker does not drain the injection queue, so these tasks are only
+  ## picked up once the pool comes back up for air.
+  for _ in 0 ..< ctx.rounds:
+    ctx.tp.spawn bump()
+
+var
+  handoff: Flowvar[int]
+  handoffFilled: Atomic[bool]
+
+proc handoffAwaiter(rounds: int) {.thread.} =
+  ## Awaits a future created by another thread. The waiter is neither the task's
+  ## creator nor a thread that ever had it in a deque, so it can only park: it
+  ## has no way to run the task itself, whoever ends up running it must wake it.
+  for _ in 0 ..< rounds:
+    while not handoffFilled.load(moAcquire):
+      cpuRelax()
+    let fv = handoff
+    doAssert sync(fv) == 1
+    handoffFilled.store(false, moRelease)
+
+suite "Per-task backoff stress":
+  setup:
+    tp = Taskpool.new(numThreads())
+    executed.store(0, moRelease)
+
+  teardown:
+    tp.syncAll()
+    tp.shutdown()
+
+  test "park vs completion sweep; 256 runtimes x 64 rounds":
+    # The awaiting thread hands the task to a thief (by idling just long enough
+    # for one to steal it), then races that thief to the park. `spins` moves the
+    # completion point across the register-waiter / set-completed / hand-over
+    # window one step at a time.
+    for spins in 0 ..< 256:
+      for _ in 0 ..< 64:
+        let fv = tp.spawn counted(spins)
+        for _ in 0 ..< 64:
+          cpuRelax() # give a thief time to take the task
+        check sync(fv) == 1
+
+  test "many live futures awaited out of order":
+    # Keeps a crowd of nodes alive at once, each in a different phase of the
+    # handover: some completed and waiting to be freed, some still running, some
+    # not yet picked up. Awaiting the odd indices first means the awaited node is
+    # rarely the one on top of our own deque, so the await rarely resolves inline.
+    const rounds = 300
+    let n = numThreads() * 16
+    for _ in 0 ..< rounds:
+      var futs = newSeq[Flowvar[int]](n)
+      for i in 0 ..< n:
+        futs[i] = tp.spawn counted((i * 7) mod 96)
+      var total = 0
+      for i in countup(1, n - 1, 2):
+        total += sync(futs[i])
+      for i in countup(0, n - 1, 2):
+        total += sync(futs[i])
+      check total == n
+
+  test "a future awaited by a thread other than its creator; 5000 rounds":
+    # The root spawns but never awaits: it leaves the task in its own deque and
+    # spins. Only a thief can complete it, and only the completion can release
+    # the parked awaiter, so every round is a wake that nobody else can supply.
+    const rounds = 5000
+    handoffFilled.store(false, moRelease)
+    var awaiter: Thread[int]
+    createThread(awaiter, handoffAwaiter, rounds)
+    for _ in 0 ..< rounds:
+      handoff = tp.spawn counted(0)
+      handoffFilled.store(true, moRelease)
+      while handoffFilled.load(moAcquire):
+        cpuRelax()
+    joinThread(awaiter)
+
+  test "dependency chain; depth=200 x 500 rounds":
+    for _ in 0 ..< 500:
+      check sync(tp.spawn chain(200)) == 200
+
+  test "fork-join tree; depth=12 x 50 rounds":
+    for _ in 0 ..< 50:
+      check sync(tp.spawn tree(12)) == 1 shl 12
+
+  test "external threads park on every await; 4 threads x 20_000 rounds":
+    const
+      externalThreads = 4
+      rounds = 20_000
+    var threads = newSeq[Thread[StressCtx]](externalThreads)
+    for t in mitems(threads):
+      createThread(t, extAwaiter, (tp, rounds))
+    joinThreads(threads)
+    check executed.load(moAcquire) == externalThreads * rounds
+
+  test "workers parked on futures while tasks are injected":
+    # Two independent liveness claims at once: the injected tasks must still be
+    # drained even though every worker that parks stops looking at the injection
+    # queue, and the chains must still complete while the queue churns.
+    const
+      externalThreads = 4
+      rounds = 50_000
+      chains = 200
+    var threads = newSeq[Thread[StressCtx]](externalThreads)
+    for t in mitems(threads):
+      createThread(t, extSubmitter, (tp, rounds))
+    for _ in 0 ..< chains:
+      check sync(tp.spawn chain(100)) == 100
+    joinThreads(threads)
+    tp.syncAll()
+    check executed.load(moAcquire) == externalThreads * rounds
+
+suite "Per-task backoff stress, oversubscribed":
+  # A 2-worker pool: far more awaits than workers, so an await that cannot be
+  # served inline parks almost every time instead of finding something to steal.
+  setup:
+    tp = Taskpool.new(2)
+    executed.store(0, moRelease)
+
+  teardown:
+    tp.syncAll()
+    tp.shutdown()
+
+  test "dependency chain; depth=200 x 500 rounds":
+    for _ in 0 ..< 500:
+      check sync(tp.spawn chain(200)) == 200
+
+  test "fork-join tree; depth=12 x 50 rounds":
+    for _ in 0 ..< 50:
+      check sync(tp.spawn tree(12)) == 1 shl 12
+
+  test "8 external threads await on a 2-worker pool; 10_000 rounds each":
+    const
+      externalThreads = 8
+      rounds = 10_000
+    var threads = newSeq[Thread[StressCtx]](externalThreads)
+    for t in mitems(threads):
+      createThread(t, extAwaiter, (tp, rounds))
+    joinThreads(threads)
+    check executed.load(moAcquire) == externalThreads * rounds


### PR DESCRIPTION
Ported from [Constantine threadpool](https://github.com/mratsim/constantine/tree/master/constantine/threadpool) (https://github.com/mratsim/constantine/pull/224)

Changes:

- Add a futex per task to await on result completion
- Move `sync` from flowvars to taskpools and deprecate `forceFuture`

The downside is awaiting a future may consume local tasks that may not possibly help advancing the awaited future, but only if cannot steal a task, and the awaited task happens to be in progress. Still better than current release v0.1.0 behavior, which is fixed in #58.

The upside is external threads (non taskpools workers) will sleep instead of always busy wait.