### PR TITLE
Bump to v0.2.1

### DIFF
--- a/taskpools.nimble
+++ b/taskpools.nimble
@@ -1,7 +1,7 @@
 mode = ScriptMode.Verbose
 
 packageName   = "taskpools"
-version       = "0.2.0"
+version       = "0.2.1"
 author        = "Status Research & Development GmbH"
 description   = "lightweight, energy-efficient, easily auditable threadpool"
 license       = "MIT"


### PR DESCRIPTION
v0.2.0 release is skipped. Nimble got bumped but never tagged.