### PR TITLE
Fix schedule race cond which causes a hang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     uses: status-im/nimbus-common-workflow/.github/workflows/common.yml@main
     with:
-      nim-versions: '["version-2-0", "version-2-2", "devel"]'
+      nim-versions: '["version-2-0", "version-2-2", "version-2-4", "devel"]'
       test-command: |
         nim -v
         nimble list --installed --version

--- a/taskpools/chase_lev_deques.nim
+++ b/taskpools/chase_lev_deques.nim
@@ -98,27 +98,6 @@ proc `[]=`[T](buf: var Buf[T], index: int, item: T) {.inline.} =
 proc `[]`[T](buf: var Buf[T], index: int): T {.inline.} =
   result = buf.rawBuffer[index and buf.mask].load(moRelaxed)
 
-proc peek*[T](deque: var ChaseLevDeque[T]): int =
-  ## Estimates the number of items pending in the deque.
-  ## In a single-producer multi-consumer setting:
-  ## - If called by the producer (owner) the true number might be less
-  ##   due to consumers stealing items concurrently.
-  ## - If called by a consumer the true number is undefined
-  ##   as other consumers also steal items concurrently and
-  ##   the producer pushes/pops them concurrently.
-  ##
-  ## If the producer peeks and this returns 0, the queue is empty.
-  ##
-  ## This is a non-locking operation.
-  let # Handle race conditions
-    b = deque.bottom.load(moRelaxed)  # Only the producer peeks in the taskpool so moRelaxed is enough
-    t = deque.top.load(moAcquire)
-
-  if b >= t:
-    return b-t
-  else:
-    return 0
-
 proc grow[T](deque: var ChaseLevDeque[T], buf: var ptr Buf[T], top, bottom: int) {.inline.} =
   ## Double the buffer size
   ## bottom is the last item index
@@ -157,7 +136,7 @@ proc teardown*[T](deque: var ChaseLevDeque[T]) =
     node = tmp
   c_free(deque.buf.load(moRelaxed))
 
-proc push*[T](deque: var ChaseLevDeque[T], item: T) =
+proc push*[T](deque: var ChaseLevDeque[T], item: T, wasEmpty: var bool) =
   ## Enqueue an item at the bottom
   ## The item should not be used afterwards.
 
@@ -179,6 +158,15 @@ proc push*[T](deque: var ChaseLevDeque[T], item: T) =
   else:
     fence(moRelease)
     deque.bottom.store(b+1, moRelaxed)
+
+  wasEmpty =
+    if t == b:
+      true
+    else:
+      # Re-check whether the items seen at the initial `top` read
+      # have since been drained; if so we are the one making the deque non-empty.
+      fence(moSequentiallyConsistent)
+      deque.top.load(moRelaxed) >= b
 
 proc pop*[T](deque: var ChaseLevDeque[T]): T =
   ## Deque an item at the bottom

--- a/taskpools/taskpools.nim
+++ b/taskpools/taskpools.nim
@@ -214,8 +214,8 @@ proc schedule(ctx: WorkerContext, tn: sink TaskNode, forceWake = false) {.inline
   # Instead of notifying every time a task is scheduled, we notify
   # only when the worker queue is empty. This is a good approximation
   # of starvation in work-stealing.
-  let wasEmpty = ctx.taskDeque[].peek() == 0
-  ctx.taskDeque[].push(tn)
+  var wasEmpty = false
+  ctx.taskDeque[].push(tn, wasEmpty)
   if forceWake or wasEmpty:
     ctx.taskpool.globalBackoff.wake()
 
@@ -233,10 +233,12 @@ proc drainInjectionQueue(ctx: var WorkerContext): bool {.inline, discardable.} =
   ## Atomically claim the entire injection queue and push all tasks into
   ## the calling worker's Chase-Lev deque, where they become stealable.
   ## Only one worker wins the exchange; the others drain nothing.
+  ## Return whether the task queue was empty before the drain.
   result = false
+  var wasEmpty = false
   for node in ctx.taskpool.injectionQueue.drain():
-    ctx.taskDeque[].push(node)
-    result = true
+    ctx.taskDeque[].push(node, wasEmpty)
+    result = result or wasEmpty
 
 # Scheduler
 # ---------------------------------------------

--- a/tests/test_all.nim
+++ b/tests/test_all.nim
@@ -20,5 +20,6 @@ import ./[
   test_nqueens,
   test_single_thread,
   test_spc,
+  test_spawn_spin,
   test_task_backoff
 ]

--- a/tests/test_spawn_spin.nim
+++ b/tests/test_spawn_spin.nim
@@ -1,0 +1,90 @@
+# taskpools
+# Copyright (c) 2021-2026 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+## Regression tests for a scheduler lost wakeup.
+
+{.push raises: [], gcsafe.}
+
+import
+  std/atomics,
+  unittest2,
+  ../taskpools
+
+const
+  sweepRounds = 400_000
+  senderBatch = 2
+    ## Two is the whole race: the first push finds the deque empty and notifies,
+    ## the second peeks while the first is still queued and must decide again.
+  pollBatch = 2
+
+type
+  Entry = object
+    ready {.align: 64.}: Atomic[bool]
+    value: Atomic[int]
+
+var
+  tp: Taskpool
+  entries: array[senderBatch, Entry]
+
+proc senderTask(i: int): bool =
+  entries[i].value.store(i * 2 + 1, moRelease)
+  entries[i].ready.store(true, moRelease)
+  true
+
+proc pollTask(i: int): int =
+  i * 3 + 1
+
+proc runSenderBatch() =
+  ## withSenderParallel: spawn a batch, wait on a side channel, sync at the end.
+  for i in 0 ..< senderBatch:
+    entries[i].ready.store(false, moRelease)
+    entries[i].value.store(0, moRelease)
+
+  var futs: array[senderBatch, Flowvar[bool]]
+  # Both land in the spawner's own deque; only an empty -> non-empty transition
+  # notifies anybody.
+  for i in 0 ..< senderBatch:
+    futs[i] = tp.spawn senderTask(i)
+
+  # Deliberately not `sync`: waiting here keeps the spawner out of the
+  # scheduler, so it never drains the deque it just filled. If the second task
+  # was stranded this spins forever, which is the intended signal.
+  for i in 0 ..< senderBatch:
+    while not entries[i].ready.load(moAcquire):
+      cpuRelax()
+    doAssert entries[i].value.load(moAcquire) == i * 2 + 1
+
+  # Only now, in the equivalent of the `finally`.
+  for i in 0 ..< senderBatch:
+    doAssert sync(futs[i])
+
+proc allReady(futs: var array[pollBatch, Flowvar[int]]): bool =
+  for i in 0 ..< pollBatch:
+    if not futs[i].isReady():
+      return false
+  true
+
+proc runPollBatch() =
+  ## aristo computeKeyImpl: spawn a batch, poll isReady, sync once ready.
+  var futs: array[pollBatch, Flowvar[int]]
+  for i in 0 ..< pollBatch:
+    futs[i] = tp.spawn pollTask(i)
+
+  while not allReady(futs):
+    cpuRelax()
+
+  for i in 0 ..< pollBatch:
+    doAssert sync(futs[i]) == i * 3 + 1
+
+suite "Spawn then wait without re-entering the scheduler":
+  test "send and poll":
+    tp = Taskpool.new(2)
+    for r in 0 ..< sweepRounds:
+      runSenderBatch()
+      runPollBatch()
+    tp.syncAll()
+    tp.shutdown()


### PR DESCRIPTION
Fix peek+push schedule race cond (which causes a hang) by doing peek, push, then re-check whether the queue got drained in between. Remove `peek` and move the check inside `push` to keep the same perf.

I submitted the fix to constantine as well https://github.com/mratsim/constantine/pull/630