### PR TITLE
Fix emscripten compile target

### DIFF
--- a/taskpools/primitives/futexes.nim
+++ b/taskpools/primitives/futexes.nim
@@ -6,7 +6,7 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-when defined(taskpoolsGenericFutex):
+when defined(emscripten) or defined(taskpoolsGenericFutex):
   import ./futexes_generic
   export futexes_generic
 elif defined(linux):


### PR DESCRIPTION
When compiling for wasm target it tries to use the linux futex which is not compatible with it.

The old Event notifier was based on lock+cond, so using the generic futex also based on lock+cond should be similar. This is needed to compile nimbus verified proxy to wasm, although it does not look like it uses taskpools really.