### PR TITLE
specify the version of unittest2 dependency

### DIFF
--- a/taskpools.nimble
+++ b/taskpools.nimble
@@ -7,7 +7,8 @@ description   = "lightweight, energy-efficient, easily auditable threadpool"
 license       = "MIT"
 skipDirs      = @["tests"]
 
-requires "nim >= 2.0.14", "unittest2"
+requires "nim >= 2.0.14",
+         "unittest2 >= 0.2.0"
 
 import strutils
 


### PR DESCRIPTION
Otherwise, nimble's `--resolver:minver` picks up unittest2 0.0.1, which doesn't work.