### PR TITLE
Fix #12; Allow GC type task result

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,6 @@ The following types and procedures are exposed:
 
 The following are non-goals:
 
-- Supporting GC-ed types with Nim default GC (sequences and strings). Using no GC or --gc:arc, --gc:orc or --gc:boehm (any GC that doesn't have thread-local heaps).
 - Having async-awaitable tasks
 - Running on environments without dynamic memory allocation
 - High-Performance Computing specificities (distribution on many machines or GPUs or machines with 200+ cores or multi-sockets)

--- a/taskpools/flowvars.nim
+++ b/taskpools/flowvars.nim
@@ -9,8 +9,10 @@
 {.push raises: [].}
 
 import
-  std/atomics,
+  std/[atomics, isolation],
   ./primitives/[allocs, futexes]
+
+const sharedHeap* = defined(gcArc) or defined(gcOrc) or defined(gcAtomicArc)
 
 # Tasks have an efficient design so that a single heap allocation
 # is required per `spawn`.
@@ -196,7 +198,10 @@ func isReady*[T](fv: Flowvar[T]): bool {.inline.} =
 proc tryComplete*[T](fv: Flowvar[T], parentResult: var T): bool {.inline.} =
   ## If the task is complete, move its result into `parentResult` and return true.
   if fv.tn.isCompleted():
-    parentResult = move(cast[ptr T](fv.tn.env.addr)[])
+    when sharedHeap:
+      parentResult = extract(cast[ptr Isolated[T]](fv.tn.env.addr)[])
+    else:
+      parentResult = move(cast[ptr T](fv.tn.env.addr)[])
     true
   else:
     false

--- a/taskpools/taskpools.nim
+++ b/taskpools/taskpools.nim
@@ -684,4 +684,4 @@ macro spawn*(tp: Taskpool, fnCall: typed): untyped =
 
   # Wrap in a block for namespacing
   result = nnkBlockStmt.newTree(newEmptyNode(), result)
-  echo result.toStrLit()
+  # echo result.toStrLit()

--- a/taskpools/taskpools.nim
+++ b/taskpools/taskpools.nim
@@ -50,8 +50,6 @@ export
   # flowvars
   Flowvar, isSpawned, isReady, isolation
 
-const sharedHeap = defined(gcArc) or defined(gcOrc) or defined(gcAtomicArc)
-
 type
   WorkerID = int32
 
@@ -569,8 +567,20 @@ macro spawn*(tp: Taskpool, fnCall: typed): untyped =
 
   if hasFuture:
     # Reserve env[0] for the return value, default-initialized until the task runs.
-    envTup.add quote do:
-      default(typeof `retType`)
+    when sharedHeap:
+      envTup.add quote do:
+        isolate(default(typeof `retType`))
+    else:
+      envTup.add quote do:
+        default(typeof `retType`)
+      let hasClosure = newLit(retType.kind == nnkSym and hasClosure(retType))
+      result.add quote do:
+        when `hasClosure` or not supportsThreadMove(typeof(`retType`)):
+          {.
+            error:
+              "Garbage-collected types (seq, string, ref, closures) cannot be used as task return: " &
+              $(typeof(`retType`))
+          .}
 
   # Continue with the runtime parameters:
   var j = argBase
@@ -594,21 +604,20 @@ macro spawn*(tp: Taskpool, fnCall: typed): untyped =
       else:
         # `move` to support move-only types in refc
         envTup.add p
-        let hasClosure = newLit(p.kind == nnkSym and hasClosure(p))
-
+        fwdCall.add quote do:
+          move(`env`[][`jl`])
         # `refc` uses a thread-local heap - therefore, anything heap-allocated
         # cannot traverse thread boundaries, even if it's isolated - since
         # tasks are likely to end up on a different thread, block their
         # construction here.
-        fwdCall.add quote do:
+        let hasClosure = newLit(p.kind == nnkSym and hasClosure(p))
+        result.add quote do:
           when `hasClosure` or not supportsThreadMove(typeof(`p`)):
             {.
               error:
                 "Garbage-collected types (seq, string, ref, closures) cannot be used as task arguments: " &
                 $(typeof(`p`))
             .}
-
-          move(`env`[][`jl`])
   let
     envp = genSym(nskParam, "envp")
       # closure environment, untyped pointer version in `fwdCall`
@@ -622,9 +631,14 @@ macro spawn*(tp: Taskpool, fnCall: typed): untyped =
 
   let body =
     if hasFuture:
-      quote do:
-        let `env` = cast[ptr `envTy`](`envp`)
-        `env`[][0] = `fwdCall`
+      when sharedHeap:
+        quote do:
+          let `env` = cast[ptr `envTy`](`envp`)
+          `env`[][0] = isolate(`fwdCall`)
+      else:
+        quote do:
+          let `env` = cast[ptr `envTy`](`envp`)
+          `env`[][0] = `fwdCall`
     elif envTup.len > 0:
       quote do:
         let `env` = cast[ptr `envTy`](`envp`)
@@ -670,4 +684,4 @@ macro spawn*(tp: Taskpool, fnCall: typed): untyped =
 
   # Wrap in a block for namespacing
   result = nnkBlockStmt.newTree(newEmptyNode(), result)
-  # echo result.toStrLit()
+  echo result.toStrLit()

--- a/tests/test_calltypes.nim
+++ b/tests/test_calltypes.nim
@@ -36,6 +36,12 @@ proc argstr(s: string): int =
 proc retstr(s: string): string =
   s
 
+proc argseq(s: seq[int]): int =
+  s.len
+
+proc retseq(s: seq[int]): seq[int] =
+  s
+
 proc retref(): ref string =
   var ret = new string
   ret[] = "hello"
@@ -136,6 +142,40 @@ suite "Call types":
       while not isReady(fv):
         discard
       check sync(fv) == "foo"
+
+    test "seq argument":
+      var futs: seq[Flowvar[int]]
+      var expected = 0
+      for i in 0 ..< 64:
+        let s = @[i]
+        expected += s.len
+        futs.add tp.spawn(argseq(s))
+      var total = 0
+      for i in 0 ..< 64:
+        total += sync futs[i]
+      check total == expected
+
+    test "seq argument variant":
+      var s = @[1, 2, 3]
+      let fv = tp.spawn argseq(s)
+      while not isReady(fv):
+        discard
+      check sync(fv) == 3
+
+    test "seq return":
+      var futs: seq[Flowvar[seq[int]]]
+      for i in 0 ..< 64:
+        let s = @[i]
+        futs.add tp.spawn(retseq(s))
+      for i in 0 ..< 64:
+        check sync(futs[i]) == @[i]
+
+    test "seq return variant":
+      var s = @[1, 2, 3]
+      let fv = tp.spawn retseq(s)
+      while not isReady(fv):
+        discard
+      check sync(fv) == @[1, 2, 3]
 
     test "ref return":
       var futs: seq[Flowvar[ref string]]

--- a/tests/test_calltypes.nim
+++ b/tests/test_calltypes.nim
@@ -24,7 +24,7 @@ proc argint(v: int) =
 proc retargint(v: int): int =
   v
 
-proc arggen*[T](v: T): int =
+proc arggen[T](v: T): int =
   5
 
 proc argtuple(v: (int, int)) =
@@ -32,6 +32,11 @@ proc argtuple(v: (int, int)) =
 
 proc argstr(s: string): int =
   s.len
+
+proc retref(): ref string =
+  var ret = new string
+  ret[] = "hello"
+  ret
 
 proc argumulti(b: bool, v: array[2, int], p: ptr int) =
   discard
@@ -93,3 +98,8 @@ suite "Call types":
       for i in 0 ..< 64:
         total += sync futs[i]
       check total == expected
+
+    test "ref return":
+      var fv = tp.spawn(retref())
+      let ret = sync(fv)
+      check ret[] == "hello"

--- a/tests/test_calltypes.nim
+++ b/tests/test_calltypes.nim
@@ -33,6 +33,9 @@ proc argtuple(v: (int, int)) =
 proc argstr(s: string): int =
   s.len
 
+proc retstr(s: string): string =
+  s
+
 proc retref(): ref string =
   var ret = new string
   ret[] = "hello"
@@ -86,6 +89,18 @@ suite "Call types":
     var v: MoveOnly
     tp.spawn(moveit(v))
 
+  when not supportsGcTypes:
+    test "string argument":
+      var s = "item"
+      check not compiles(tp.spawn(argstr(s)))
+
+    test "string return":
+      var s = "item"
+      check not compiles(tp.spawn(retstr(s)))
+
+    test "ref return":
+      check not compiles(tp.spawn(retref()))
+
   when supportsGcTypes:
     test "string argument":
       var futs: seq[Flowvar[int]]
@@ -99,7 +114,11 @@ suite "Call types":
         total += sync futs[i]
       check total == expected
 
+    test "string return":
+      var s = "foo"
+      let ret = sync tp.spawn(retstr(s))
+      check ret == "foo"
+
     test "ref return":
-      var fv = tp.spawn(retref())
-      let ret = sync(fv)
+      let ret = sync tp.spawn(retref())
       check ret[] == "hello"

--- a/tests/test_calltypes.nim
+++ b/tests/test_calltypes.nim
@@ -114,11 +114,38 @@ suite "Call types":
         total += sync futs[i]
       check total == expected
 
-    test "string return":
+    test "string argument variant":
       var s = "foo"
-      let ret = sync tp.spawn(retstr(s))
-      check ret == "foo"
+      let fv = tp.spawn argstr(s)
+      # force run in another thread
+      while not isReady(fv):
+        discard
+      check sync(fv) == 3
+
+    test "string return":
+      var futs: seq[Flowvar[string]]
+      for i in 0 ..< 64:
+        let s = "item" & $i
+        futs.add tp.spawn(retstr(s))
+      for i in 0 ..< 64:
+        check sync(futs[i]) == "item" & $i
+
+    test "string return variant":
+      var s = "foo"
+      let fv = tp.spawn retstr(s)
+      while not isReady(fv):
+        discard
+      check sync(fv) == "foo"
 
     test "ref return":
-      let ret = sync tp.spawn(retref())
-      check ret[] == "hello"
+      var futs: seq[Flowvar[ref string]]
+      for i in 0 ..< 64:
+        futs.add tp.spawn(retref())
+      for i in 0 ..< 64:
+        check sync(futs[i])[] == "hello"
+
+    test "ref return variant":
+      let fv = tp.spawn retref()
+      while not isReady(fv):
+        discard
+      check sync(fv)[] == "hello"


### PR DESCRIPTION
Fix #12

Changes:

- isolate task result in arc, orc
- prevent gc type result in refc
- minor refc refactor so the checks are done "top-level" so the macro output is more readable

note the issue *seems* fixed since #56 for strings, at least ASan/TSan does not complain. Isolate does more comptime checks to prevent returning unsafe results; ex: a threadvar ref, cyclic ref...